### PR TITLE
Add Solax X1 Mini G2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ ESPHome component to monitor a Solax X1 mini via RS485.
 
 ![Lovelace entities card](lovelace-entities-card.png "lovelace entities card")
 
+## Supported devices
+
+* Solax X1 Mini
+* Solax X1 Mini G2
+
 ## Requirements
 
 * [ESPHome 1.18.0 or higher](https://github.com/esphome/esphome/releases).

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ ESPHome component to monitor a Solax X1 mini via RS485.
 
 ## Supported devices
 
-* Solax X1 Mini
-* Solax X1 Mini G2
+* SolaX X1 Mini
+  - SolaX X1 Mini X1-0.6-S-D
+* SolaX X1 Mini G2
+  - SolaX X1 Mini X1-2.0-S-D(L) (master version 1.08, manager version 1.07) (reported by [@zcloud-at](https://github.com/syssi/esphome-modbus-solax-x1/issues/15))
 
 ## Requirements
 

--- a/components/solax_x1/solax_x1.cpp
+++ b/components/solax_x1/solax_x1.cpp
@@ -72,7 +72,14 @@ void SolaxX1::on_modbus_solax_info(const std::vector<uint8_t> &data) {
 }
 
 void SolaxX1::on_modbus_solax_data(const std::vector<uint8_t> &data) {
-  if (data.size() != 52) {
+  if (data.size() != 52 && data.size() != 50) {
+    // Solax X1 mini status report:
+    // AA.55.00.0A.01.00.11.82.34.00.1A.00.02.00.00.00.00.00.00.00.00.00.00.09.21.13.87.00.00.FF.FF.
+    // 00.00.00.12.00.00.00.15.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.04.D6
+
+    // Solax X1 mini g2 status report:
+    // AA.55.00.0A.01.00.11.82.32.00.21.00.02.07.EC.00.00.00.1D.00.00.00.18.09.55.13.80.02.2B.FF.FF.
+    // 00.00.5D.AF.00.00.10.50.00.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.07.A4
     ESP_LOGW(TAG, "Invalid response size: %zu", data.size());
     return;
   }

--- a/components/solax_x1/solax_x1.cpp
+++ b/components/solax_x1/solax_x1.cpp
@@ -81,6 +81,10 @@ void SolaxX1::on_modbus_solax_data(const std::vector<uint8_t> &data) {
     // AA.55.00.0A.01.00.11.82.32.00.21.00.02.07.EC.00.00.00.1D.00.00.00.18.09.55.13.80.02.2B.FF.FF.
     // 00.00.5D.AF.00.00.10.50.00.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.07.A4
     ESP_LOGW(TAG, "Invalid response size: %zu", data.size());
+    ESP_LOGW(TAG, "Your device is probably not supported. Please create an issue here: "
+                  "https://github.com/syssi/esphome-modbus-solax-x1/issues");
+    ESP_LOGW(TAG, "Please provide the following status response data: %s",
+             format_hex_pretty(&data.front(), data.size()).c_str());
     return;
   }
 


### PR DESCRIPTION
Closes: #15

```
external_components:
  - source: github://syssi/esphome-modbus-solax-x1@add-solax-x1-mini-g2-compatibility
    refresh: 0s
```

SolaX X1 mini inverter model X1-2.0-S-D(L). Master version 1.08, Manager version 1.07.