### PR TITLE
Add Solax X1 Mini G3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ ESPHome component to monitor a Solax X1 mini via RS485.
 * SolaX X1 Mini G2
   - SolaX X1 Mini X1-1.5-S-D(L) (master version 1.08, manager version 1.07) (reported by [@beocycris](https://github.com/syssi/esphome-modbus-solax-x1/issues/18#issuecomment-1073188868))
   - SolaX X1 Mini X1-2.0-S-D(L) (master version 1.08, manager version 1.07) (reported by [@zcloud-at](https://github.com/syssi/esphome-modbus-solax-x1/issues/15))
+* SolaX X1 Mini G3
+  - SolaX X1 Mini X1-2.0-S-D(L) (master version 1.08, manager version 1.07) (reported by [@neujbit](https://github.com/syssi/esphome-modbus-solax-x1/issues/22))
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ESPHome component to monitor a Solax X1 mini via RS485.
   - SolaX X1 Mini X1-1.5-S-D(L) (master version 1.08, manager version 1.07) (reported by [@beocycris](https://github.com/syssi/esphome-modbus-solax-x1/issues/18#issuecomment-1073188868))
   - SolaX X1 Mini X1-2.0-S-D(L) (master version 1.08, manager version 1.07) (reported by [@zcloud-at](https://github.com/syssi/esphome-modbus-solax-x1/issues/15))
 * SolaX X1 Mini G3
-  - SolaX X1 Mini X1-2.0-S-D(L) (master version 1.08, manager version 1.07) (reported by [@neujbit](https://github.com/syssi/esphome-modbus-solax-x1/issues/22))
+  - SolaX X1 Mini X1-0.6-S-D(L) (master version 1.08, manager version 1.07) (reported by [@neujbit](https://github.com/syssi/esphome-modbus-solax-x1/issues/22))
 
 ## Requirements
 

--- a/components/solax_x1/solax_x1.cpp
+++ b/components/solax_x1/solax_x1.cpp
@@ -82,8 +82,8 @@ void SolaxX1::on_modbus_solax_data(const std::vector<uint8_t> &data) {
     // 00.00.5D.AF.00.00.10.50.00.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.07.A4
 
     // Solax X1 mini g3 status report:
-    // ...........................00.17.00.00.03.DE.00.00.00.08.00.00.00.05.09.06.13.85.00.48.FF.FF.
-    // 00.00.00.28.00.00.00.0C.00.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.01.00.8A.00.DE
+    // AA.55.00.0A.01.00.11.82.38.00.1A.00.03.04.0C.00.00.00.19.00.00.00.0B.08.FC.13.8A.00.F8.FF.FF.
+    // 00.00.00.2B.00.00.00.0D.00.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.8A.00.DE.08.5F
     ESP_LOGW(TAG, "Invalid response size: %zu", data.size());
     ESP_LOGW(TAG, "Your device is probably not supported. Please create an issue here: "
                   "https://github.com/syssi/esphome-modbus-solax-x1/issues");

--- a/components/solax_x1/solax_x1.cpp
+++ b/components/solax_x1/solax_x1.cpp
@@ -72,7 +72,7 @@ void SolaxX1::on_modbus_solax_info(const std::vector<uint8_t> &data) {
 }
 
 void SolaxX1::on_modbus_solax_data(const std::vector<uint8_t> &data) {
-  if (data.size() != 52 && data.size() != 50) {
+  if (data.size() != 52 && data.size() != 50 && data.size() != 56) {
     // Solax X1 mini status report:
     // AA.55.00.0A.01.00.11.82.34.00.1A.00.02.00.00.00.00.00.00.00.00.00.00.09.21.13.87.00.00.FF.FF.
     // 00.00.00.12.00.00.00.15.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.04.D6
@@ -80,6 +80,10 @@ void SolaxX1::on_modbus_solax_data(const std::vector<uint8_t> &data) {
     // Solax X1 mini g2 status report:
     // AA.55.00.0A.01.00.11.82.32.00.21.00.02.07.EC.00.00.00.1D.00.00.00.18.09.55.13.80.02.2B.FF.FF.
     // 00.00.5D.AF.00.00.10.50.00.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.07.A4
+
+    // Solax X1 mini g3 status report:
+    // ...........................00.17.00.00.03.DE.00.00.00.08.00.00.00.05.09.06.13.85.00.48.FF.FF.
+    // 00.00.00.28.00.00.00.0C.00.02.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.01.00.8A.00.DE
     ESP_LOGW(TAG, "Invalid response size: %zu", data.size());
     ESP_LOGW(TAG, "Your device is probably not supported. Please create an issue here: "
                   "https://github.com/syssi/esphome-modbus-solax-x1/issues");


### PR DESCRIPTION
Closes: #22

```
external_components:
  - source: github://syssi/esphome-modbus-solax-x1@add-x1-mini-g3-support
    refresh: 0s
```