### PR TITLE
Move minimum ESPHome version requirement into validator

### DIFF
--- a/components/solax_modbus/__init__.py
+++ b/components/solax_modbus/__init__.py
@@ -17,7 +17,8 @@ solax_modbus_ns = cg.esphome_ns.namespace("solax_modbus")
 SolaxModbus = solax_modbus_ns.class_("SolaxModbus", cg.Component, uart.UARTDevice)
 SolaxModbusDevice = solax_modbus_ns.class_("SolaxModbusDevice")
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 6, 0),
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SolaxModbus),

--- a/components/solax_modbus/__init__.py
+++ b/components/solax_modbus/__init__.py
@@ -26,7 +26,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
 )
 
 

--- a/components/solax_x1_mini/__init__.py
+++ b/components/solax_x1_mini/__init__.py
@@ -26,7 +26,7 @@ CONFIG_SCHEMA = cv.All(
     .extend(cv.polling_component_schema("30s"))
     .extend(
         solax_modbus.solax_modbus_device_schema(0x0A, "3132333435363737363534333231")
-    )
+    ),
 )
 
 

--- a/components/solax_x1_mini/__init__.py
+++ b/components/solax_x1_mini/__init__.py
@@ -20,7 +20,8 @@ CONF_SOLAX_X1_MINI_COMPONENT_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
+    cv.require_esphome_version(2024, 6, 0),
     cv.Schema({cv.GenerateID(): cv.declare_id(SolaxX1Mini)})
     .extend(cv.polling_component_schema("30s"))
     .extend(

--- a/esp32-example-advanced-multiple-uarts.yaml
+++ b/esp32-example-advanced-multiple-uarts.yaml
@@ -9,7 +9,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-solax-x1-mini"
     version: 2.6.0

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-solax-x1-mini"
     version: 2.6.0

--- a/esp32-meter-gateway.yaml
+++ b/esp32-meter-gateway.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-solax-x1-mini"
     version: 2.6.0

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-solax-x1-mini"
     version: 2.6.0

--- a/esp8266-meter-gateway-multiple-uarts.yaml
+++ b/esp8266-meter-gateway-multiple-uarts.yaml
@@ -10,7 +10,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-modbus-solax-x1"
     version: 2.6.0

--- a/esp8266-meter-gateway.yaml
+++ b/esp8266-meter-gateway.yaml
@@ -8,7 +8,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-solax-x1-mini"
     version: 2.6.0

--- a/modbus-examples/esp32-solax-x1-boost.yaml
+++ b/modbus-examples/esp32-solax-x1-boost.yaml
@@ -19,7 +19,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
   project:
     name: "syssi.esphome-solax-x1-mini"
     version: 2.6.0

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,7 +6,6 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2025.6.0
 
 esp32:
   board: esp32-c6-devkitc-1

--- a/tests/esp8266-dummy-receiver.yaml
+++ b/tests/esp8266-dummy-receiver.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-query-sdm230-floats.yaml
+++ b/tests/esp8266-query-sdm230-floats.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-query-sdm230.yaml
+++ b/tests/esp8266-query-sdm230.yaml
@@ -5,7 +5,6 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
Removes min_version from all YAML configurations and enforces the version constraint via cv.require_esphome_version() in the component validator instead.