### PR TITLE
Explicitly initialize all pointer members to nullptr

### DIFF
--- a/components/solax_meter_gateway/solax_meter_gateway.h
+++ b/components/solax_meter_gateway/solax_meter_gateway.h
@@ -42,15 +42,15 @@ class SolaxMeterGateway : public PollingComponent, public solax_meter_modbus::So
   float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
-  number::Number *manual_power_demand_number_;
+  number::Number *manual_power_demand_number_{nullptr};
 
-  sensor::Sensor *power_sensor_;
-  sensor::Sensor *power_demand_sensor_;
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *power_demand_sensor_{nullptr};
 
-  switch_::Switch *manual_mode_switch_;
-  switch_::Switch *emergency_power_off_switch_;
+  switch_::Switch *manual_mode_switch_{nullptr};
+  switch_::Switch *emergency_power_off_switch_{nullptr};
 
-  text_sensor::TextSensor *operation_mode_text_sensor_;
+  text_sensor::TextSensor *operation_mode_text_sensor_{nullptr};
 
   float power_demand_;
   uint16_t power_sensor_inactivity_timeout_s_{0};

--- a/components/solax_x1_mini/solax_x1_mini.h
+++ b/components/solax_x1_mini/solax_x1_mini.h
@@ -55,30 +55,30 @@ class SolaxX1Mini : public PollingComponent, public solax_modbus::SolaxModbusDev
   void dump_config() override;
 
  protected:
-  sensor::Sensor *energy_today_sensor_;
-  sensor::Sensor *energy_total_sensor_;
-  sensor::Sensor *dc1_current_sensor_;
-  sensor::Sensor *dc2_current_sensor_;
-  sensor::Sensor *dc1_voltage_sensor_;
-  sensor::Sensor *dc2_voltage_sensor_;
-  sensor::Sensor *ac_current_sensor_;
-  sensor::Sensor *ac_frequency_sensor_;
-  sensor::Sensor *ac_power_sensor_;
-  sensor::Sensor *ac_voltage_sensor_;
-  sensor::Sensor *temperature_sensor_;
-  sensor::Sensor *mode_sensor_;
-  sensor::Sensor *error_bits_sensor_;
-  sensor::Sensor *runtime_total_sensor_;
-  sensor::Sensor *grid_voltage_fault_sensor_;
-  sensor::Sensor *grid_frequency_fault_sensor_;
-  sensor::Sensor *dc_injection_fault_sensor_;
-  sensor::Sensor *temperature_fault_sensor_;
-  sensor::Sensor *pv1_voltage_fault_sensor_;
-  sensor::Sensor *pv2_voltage_fault_sensor_;
-  sensor::Sensor *gfc_fault_sensor_;
+  sensor::Sensor *energy_today_sensor_{nullptr};
+  sensor::Sensor *energy_total_sensor_{nullptr};
+  sensor::Sensor *dc1_current_sensor_{nullptr};
+  sensor::Sensor *dc2_current_sensor_{nullptr};
+  sensor::Sensor *dc1_voltage_sensor_{nullptr};
+  sensor::Sensor *dc2_voltage_sensor_{nullptr};
+  sensor::Sensor *ac_current_sensor_{nullptr};
+  sensor::Sensor *ac_frequency_sensor_{nullptr};
+  sensor::Sensor *ac_power_sensor_{nullptr};
+  sensor::Sensor *ac_voltage_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *mode_sensor_{nullptr};
+  sensor::Sensor *error_bits_sensor_{nullptr};
+  sensor::Sensor *runtime_total_sensor_{nullptr};
+  sensor::Sensor *grid_voltage_fault_sensor_{nullptr};
+  sensor::Sensor *grid_frequency_fault_sensor_{nullptr};
+  sensor::Sensor *dc_injection_fault_sensor_{nullptr};
+  sensor::Sensor *temperature_fault_sensor_{nullptr};
+  sensor::Sensor *pv1_voltage_fault_sensor_{nullptr};
+  sensor::Sensor *pv2_voltage_fault_sensor_{nullptr};
+  sensor::Sensor *gfc_fault_sensor_{nullptr};
 
-  text_sensor::TextSensor *mode_name_text_sensor_;
-  text_sensor::TextSensor *errors_text_sensor_;
+  text_sensor::TextSensor *mode_name_text_sensor_{nullptr};
+  text_sensor::TextSensor *errors_text_sensor_{nullptr};
   uint8_t no_response_count_ = REDISCOVERY_THRESHOLD;
 
   void decode_device_info_(const std::vector<uint8_t> &data);


### PR DESCRIPTION
## Summary
- Add `{nullptr}` in-class initializer to all raw pointer members in component header files that previously had no initializer
- Aligns with ESPHome core style: every component in the ESPHome core uses `{nullptr}` for pointer members — no uninitialized pointer exists in the core codebase
- While ESPHome instantiates components via `new T()` (value-initializes to zero), explicit `{nullptr}` makes the intent unambiguous and matches the upstream convention