### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and number schemas

### DIFF
--- a/components/solax_meter_gateway/number/__init__.py
+++ b/components/solax_meter_gateway/number/__init__.py
@@ -75,8 +75,7 @@ CONFIG_SCHEMA = cv.Schema(
                     cv.Optional(CONF_INITIAL_VALUE): cv.float_,
                     cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
                 }
-            )
-            .extend(cv.COMPONENT_SCHEMA),
+            ),
             validate_min_max,
             validate,
         ),

--- a/components/solax_meter_gateway/number/__init__.py
+++ b/components/solax_meter_gateway/number/__init__.py
@@ -62,8 +62,7 @@ CONFIG_SCHEMA = cv.Schema(
                 SolaxNumber,
                 icon=ICON_MANUAL_POWER_DEMAND,
                 unit_of_measurement=UNIT_WATT,
-            )
-            .extend(
+            ).extend(
                 {
                     cv.Optional(
                         CONF_MIN_VALUE, default=DEFAULT_MIN_POWER_DEMAND

--- a/components/solax_meter_gateway/switch/__init__.py
+++ b/components/solax_meter_gateway/switch/__init__.py
@@ -46,8 +46,7 @@ CONFIG_SCHEMA = CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA.extend(
                     RESTORE_MODES, upper=True, space="_"
                 ),
             }
-        )
-        .extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_EMERGENCY_POWER_OFF): switch.switch_schema(
             SolaxSwitch,
             icon=ICON_EMERGENCY_POWER_OFF,
@@ -58,8 +57,7 @@ CONFIG_SCHEMA = CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA.extend(
                     RESTORE_MODES, upper=True, space="_"
                 ),
             }
-        )
-        .extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/solax_meter_gateway/switch/__init__.py
+++ b/components/solax_meter_gateway/switch/__init__.py
@@ -39,8 +39,7 @@ CONFIG_SCHEMA = CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_MANUAL_MODE): switch.switch_schema(
             SolaxSwitch,
             icon=ICON_MANUAL_MODE,
-        )
-        .extend(
+        ).extend(
             {
                 cv.Optional(CONF_RESTORE_MODE, default="RESTORE_DEFAULT_OFF"): cv.enum(
                     RESTORE_MODES, upper=True, space="_"
@@ -50,8 +49,7 @@ CONFIG_SCHEMA = CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_EMERGENCY_POWER_OFF): switch.switch_schema(
             SolaxSwitch,
             icon=ICON_EMERGENCY_POWER_OFF,
-        )
-        .extend(
+        ).extend(
             {
                 cv.Optional(CONF_RESTORE_MODE, default="RESTORE_DEFAULT_OFF"): cv.enum(
                     RESTORE_MODES, upper=True, space="_"


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from `switch.switch_schema()` and `number.number_schema()` calls in `solax_meter_gateway`
- `switch_schema()` and `number_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant
- Top-level `CONFIG_SCHEMA` definitions in `solax_modbus` and `solax_meter_modbus` are intentionally left untouched