### PR TITLE
Add state_class to some schemas

### DIFF
--- a/components/solax_meter_gateway/number/__init__.py
+++ b/components/solax_meter_gateway/number/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ID,
     CONF_INITIAL_VALUE,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
@@ -87,15 +86,13 @@ async def to_code(config):
     for key, address in NUMBERS.items():
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
-            await cg.register_component(var, conf)
-            await number.register_number(
-                var,
+            var = await number.new_number(
                 conf,
                 min_value=conf[CONF_MIN_VALUE],
                 max_value=conf[CONF_MAX_VALUE],
                 step=conf[CONF_STEP],
             )
+            await cg.register_component(var, conf)
             cg.add(getattr(hub, f"set_{key}_number")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_initial_value(conf[CONF_INITIAL_VALUE]))

--- a/components/solax_meter_gateway/sensor.py
+++ b/components/solax_meter_gateway/sensor.py
@@ -1,7 +1,12 @@
 import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_POWER, ICON_EMPTY, STATE_CLASS_MEASUREMENT, UNIT_WATT
+from esphome.const import (
+    DEVICE_CLASS_POWER,
+    ICON_EMPTY,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_WATT,
+)
 
 from . import CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA, CONF_SOLAX_METER_GATEWAY_ID
 

--- a/components/solax_meter_gateway/sensor.py
+++ b/components/solax_meter_gateway/sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_POWER, ICON_EMPTY, UNIT_WATT
+from esphome.const import DEVICE_CLASS_POWER, ICON_EMPTY, STATE_CLASS_MEASUREMENT, UNIT_WATT
 
 from . import CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA, CONF_SOLAX_METER_GATEWAY_ID
 
@@ -16,6 +16,7 @@ CONFIG_SCHEMA = CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA.extend(
             icon=ICON_EMPTY,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
         ),
     }
 )

--- a/components/solax_meter_gateway/switch/__init__.py
+++ b/components/solax_meter_gateway/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_RESTORE_MODE
+from esphome.const import CONF_RESTORE_MODE
 
 from .. import (
     CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA,
@@ -65,9 +65,8 @@ async def to_code(config):
     for key in SWITCHES:
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await switch.new_switch(conf)
             await cg.register_component(var, conf)
-            await switch.register_switch(var, conf)
             cg.add(getattr(hub, f"set_{key}_switch")(var))
             cg.add(var.set_parent(hub))
             cg.add(var.set_restore_mode(conf[CONF_RESTORE_MODE]))


### PR DESCRIPTION
Add state_class to all sensor schemas: STATE_CLASS_MEASUREMENT for instantaneous values, STATE_CLASS_TOTAL_INCREASING for monotonically increasing counters, STATE_CLASS_TOTAL for accumulators that can decrease. This enables proper long-term statistics in Home Assistant.