### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/solax_meter_gateway/sensor.py
+++ b/components/solax_meter_gateway/sensor.py
@@ -11,6 +11,7 @@ from esphome.const import (
 from . import CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA, CONF_SOLAX_METER_GATEWAY_ID
 
 DEPENDENCIES = ["solax_meter_gateway"]
+CODEOWNERS = ["@syssi"]
 
 CONF_POWER_DEMAND = "power_demand"
 

--- a/components/solax_meter_modbus/__init__.py
+++ b/components/solax_meter_modbus/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ADDRESS, CONF_FLOW_CONTROL_PIN, CONF_ID
 from esphome.cpp_helpers import gpio_pin_expression
 
 DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@syssi"]
 MULTI_CONF = True
 
 CONF_SOLAX_METER_MODBUS_ID = "solax_meter_modbus_id"

--- a/components/solax_x1_mini/sensor.py
+++ b/components/solax_x1_mini/sensor.py
@@ -28,6 +28,7 @@ from esphome.const import (
 from . import CONF_SOLAX_X1_MINI_COMPONENT_SCHEMA, CONF_SOLAX_X1_MINI_ID
 
 DEPENDENCIES = ["solax_x1_mini"]
+CODEOWNERS = ["@syssi"]
 
 CONF_ENERGY_TODAY = "energy_today"
 CONF_ENERGY_TOTAL = "energy_total"

--- a/components/solax_x1_mini/text_sensor.py
+++ b/components/solax_x1_mini/text_sensor.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from . import CONF_SOLAX_X1_MINI_COMPONENT_SCHEMA, CONF_SOLAX_X1_MINI_ID
 
 DEPENDENCIES = ["solax_x1_mini"]
+CODEOWNERS = ["@syssi"]
 
 CONF_MODE_NAME = "mode_name"
 CONF_ERRORS = "errors"


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `solax_x1_mini/sensor.py`, `solax_x1_mini/text_sensor.py`, `solax_meter_gateway/sensor.py`, and `solax_meter_modbus/__init__.py` for consistency with other ESPHome components.