### PR TITLE
Fix text_sensor_schema positional arg and add diagnostic entity category

### DIFF
--- a/components/solax_meter_gateway/text_sensor.py
+++ b/components/solax_meter_gateway/text_sensor.py
@@ -19,7 +19,6 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_OPERATION_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_OPERATION_MODE,
         ),
     }

--- a/components/solax_x1_mini/text_sensor.py
+++ b/components/solax_x1_mini/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_SOLAX_X1_MINI_COMPONENT_SCHEMA, CONF_SOLAX_X1_MINI_ID
 
@@ -16,10 +17,11 @@ ICON_ERRORS = "mdi:alert-circle-outline"
 CONFIG_SCHEMA = CONF_SOLAX_X1_MINI_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_MODE_NAME): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_MODE_NAME
+            icon=ICON_MODE_NAME
         ),
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor, icon=ICON_ERRORS
+            icon=ICON_ERRORS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` calls in `solax_x1_mini` and `solax_meter_gateway` (T1)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC` to `errors` sensor in `solax_x1_mini` (T2)

Follows the pattern established in `esphome-tianpower-bms`.