### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-example-advanced-multiple-uarts.yaml
+++ b/esp32-example-advanced-multiple-uarts.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-solax-x1-mini"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -57,51 +57,51 @@ solax_x1_mini:
 text_sensor:
   - platform: solax_x1_mini
     mode_name:
-      name: "${name} mode name"
+      name: "mode name"
     errors:
-      name: "${name} errors"
+      name: "errors"
 
 sensor:
   - platform: solax_x1_mini
     ac_power:
-      name: "${name} ac power"
+      name: "ac power"
     energy_today:
-      name: "${name} energy today"
+      name: "energy today"
     energy_total:
-      name: "${name} energy total"
+      name: "energy total"
     dc1_voltage:
-      name: "${name} dc1 voltage"
+      name: "dc1 voltage"
     dc2_voltage:
-      name: "${name} dc2 voltage"
+      name: "dc2 voltage"
     dc1_current:
-      name: "${name} dc1 current"
+      name: "dc1 current"
     dc2_current:
-      name: "${name} dc2 current"
+      name: "dc2 current"
     ac_current:
-      name: "${name} ac current"
+      name: "ac current"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     runtime_total:
-      name: "${name} runtime total"
+      name: "runtime total"
     mode:
-      name: "${name} mode"
+      name: "mode"
     error_bits:
-      name: "${name} error bits"
+      name: "error bits"
     grid_voltage_fault:
-      name: "${name} grid voltage fault"
+      name: "grid voltage fault"
     grid_frequency_fault:
-      name: "${name} grid frequency fault"
+      name: "grid frequency fault"
     dc_injection_fault:
-      name: "${name} dc injection fault"
+      name: "dc injection fault"
     temperature_fault:
-      name: "${name} temperature fault"
+      name: "temperature fault"
     pv1_voltage_fault:
-      name: "${name} pv1 voltage fault"
+      name: "pv1 voltage fault"
     pv2_voltage_fault:
-      name: "${name} pv2 voltage fault"
+      name: "pv2 voltage fault"
     gfc_fault:
-      name: "${name} gfc fault"
+      name: "gfc fault"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-solax-x1-mini"

--- a/esp32-meter-gateway.yaml
+++ b/esp32-meter-gateway.yaml
@@ -57,51 +57,51 @@ solax_x1_mini:
 text_sensor:
   - platform: solax_x1_mini
     mode_name:
-      name: "${name} mode name"
+      name: "mode name"
     errors:
-      name: "${name} errors"
+      name: "errors"
 
 sensor:
   - platform: solax_x1_mini
     ac_power:
-      name: "${name} ac power"
+      name: "ac power"
     energy_today:
-      name: "${name} energy today"
+      name: "energy today"
     energy_total:
-      name: "${name} energy total"
+      name: "energy total"
     dc1_voltage:
-      name: "${name} dc1 voltage"
+      name: "dc1 voltage"
     dc2_voltage:
-      name: "${name} dc2 voltage"
+      name: "dc2 voltage"
     dc1_current:
-      name: "${name} dc1 current"
+      name: "dc1 current"
     dc2_current:
-      name: "${name} dc2 current"
+      name: "dc2 current"
     ac_current:
-      name: "${name} ac current"
+      name: "ac current"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     runtime_total:
-      name: "${name} runtime total"
+      name: "runtime total"
     mode:
-      name: "${name} mode"
+      name: "mode"
     error_bits:
-      name: "${name} error bits"
+      name: "error bits"
     grid_voltage_fault:
-      name: "${name} grid voltage fault"
+      name: "grid voltage fault"
     grid_frequency_fault:
-      name: "${name} grid frequency fault"
+      name: "grid frequency fault"
     dc_injection_fault:
-      name: "${name} dc injection fault"
+      name: "dc injection fault"
     temperature_fault:
-      name: "${name} temperature fault"
+      name: "temperature fault"
     pv1_voltage_fault:
-      name: "${name} pv1 voltage fault"
+      name: "pv1 voltage fault"
     pv2_voltage_fault:
-      name: "${name} pv2 voltage fault"
+      name: "pv2 voltage fault"
     gfc_fault:
-      name: "${name} gfc fault"
+      name: "gfc fault"

--- a/esp32-meter-gateway.yaml
+++ b/esp32-meter-gateway.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-solax-x1-mini"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -57,51 +57,51 @@ solax_x1_mini:
 text_sensor:
   - platform: solax_x1_mini
     mode_name:
-      name: "${name} mode name"
+      name: "mode name"
     errors:
-      name: "${name} errors"
+      name: "errors"
 
 sensor:
   - platform: solax_x1_mini
     ac_power:
-      name: "${name} ac power"
+      name: "ac power"
     energy_today:
-      name: "${name} energy today"
+      name: "energy today"
     energy_total:
-      name: "${name} energy total"
+      name: "energy total"
     dc1_voltage:
-      name: "${name} dc1 voltage"
+      name: "dc1 voltage"
     dc2_voltage:
-      name: "${name} dc2 voltage"
+      name: "dc2 voltage"
     dc1_current:
-      name: "${name} dc1 current"
+      name: "dc1 current"
     dc2_current:
-      name: "${name} dc2 current"
+      name: "dc2 current"
     ac_current:
-      name: "${name} ac current"
+      name: "ac current"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     runtime_total:
-      name: "${name} runtime total"
+      name: "runtime total"
     mode:
-      name: "${name} mode"
+      name: "mode"
     error_bits:
-      name: "${name} error bits"
+      name: "error bits"
     grid_voltage_fault:
-      name: "${name} grid voltage fault"
+      name: "grid voltage fault"
     grid_frequency_fault:
-      name: "${name} grid frequency fault"
+      name: "grid frequency fault"
     dc_injection_fault:
-      name: "${name} dc injection fault"
+      name: "dc injection fault"
     temperature_fault:
-      name: "${name} temperature fault"
+      name: "temperature fault"
     pv1_voltage_fault:
-      name: "${name} pv1 voltage fault"
+      name: "pv1 voltage fault"
     pv2_voltage_fault:
-      name: "${name} pv2 voltage fault"
+      name: "pv2 voltage fault"
     gfc_fault:
-      name: "${name} gfc fault"
+      name: "gfc fault"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-solax-x1-mini"

--- a/esp8266-meter-gateway-multiple-uarts.yaml
+++ b/esp8266-meter-gateway-multiple-uarts.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-modbus-solax-x1"

--- a/esp8266-meter-gateway.yaml
+++ b/esp8266-meter-gateway.yaml
@@ -57,51 +57,51 @@ solax_x1_mini:
 text_sensor:
   - platform: solax_x1_mini
     mode_name:
-      name: "${name} mode name"
+      name: "mode name"
     errors:
-      name: "${name} errors"
+      name: "errors"
 
 sensor:
   - platform: solax_x1_mini
     ac_power:
-      name: "${name} ac power"
+      name: "ac power"
     energy_today:
-      name: "${name} energy today"
+      name: "energy today"
     energy_total:
-      name: "${name} energy total"
+      name: "energy total"
     dc1_voltage:
-      name: "${name} dc1 voltage"
+      name: "dc1 voltage"
     dc2_voltage:
-      name: "${name} dc2 voltage"
+      name: "dc2 voltage"
     dc1_current:
-      name: "${name} dc1 current"
+      name: "dc1 current"
     dc2_current:
-      name: "${name} dc2 current"
+      name: "dc2 current"
     ac_current:
-      name: "${name} ac current"
+      name: "ac current"
     ac_voltage:
-      name: "${name} ac voltage"
+      name: "ac voltage"
     ac_frequency:
-      name: "${name} ac frequency"
+      name: "ac frequency"
     temperature:
-      name: "${name} temperature"
+      name: "temperature"
     runtime_total:
-      name: "${name} runtime total"
+      name: "runtime total"
     mode:
-      name: "${name} mode"
+      name: "mode"
     error_bits:
-      name: "${name} error bits"
+      name: "error bits"
     grid_voltage_fault:
-      name: "${name} grid voltage fault"
+      name: "grid voltage fault"
     grid_frequency_fault:
-      name: "${name} grid frequency fault"
+      name: "grid frequency fault"
     dc_injection_fault:
-      name: "${name} dc injection fault"
+      name: "dc injection fault"
     temperature_fault:
-      name: "${name} temperature fault"
+      name: "temperature fault"
     pv1_voltage_fault:
-      name: "${name} pv1 voltage fault"
+      name: "pv1 voltage fault"
     pv2_voltage_fault:
-      name: "${name} pv2 voltage fault"
+      name: "pv2 voltage fault"
     gfc_fault:
-      name: "${name} gfc fault"
+      name: "gfc fault"

--- a/esp8266-meter-gateway.yaml
+++ b/esp8266-meter-gateway.yaml
@@ -7,6 +7,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-solax-x1-mini"

--- a/modbus-examples/esp32-solax-x1-boost.yaml
+++ b/modbus-examples/esp32-solax-x1-boost.yaml
@@ -67,7 +67,7 @@ modbus_controller:
 text_sensor:
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} operation mode"
+    name: "operation mode"
     address: 0x40f
     register_type: read
     raw_encode: HEXBYTES
@@ -91,7 +91,7 @@ text_sensor:
 sensor:
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} PV1 input voltage"
+    name: "PV1 input voltage"
     address: 0x400
     register_type: read
     value_type: U_WORD
@@ -104,7 +104,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} PV2 iput vltage"
+    name: "PV2 iput vltage"
     address: 0x401
     register_type: read
     value_type: U_WORD
@@ -117,7 +117,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} PV1 iput crrent"
+    name: "PV1 iput crrent"
     address: 0x402
     register_type: read
     value_type: U_WORD
@@ -130,7 +130,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} PV2 input current"
+    name: "PV2 input current"
     address: 0x403
     register_type: read
     value_type: U_WORD
@@ -143,7 +143,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} grid voltage"
+    name: "grid voltage"
     address: 0x404
     register_type: read
     value_type: U_WORD
@@ -156,7 +156,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} grid frequency"
+    name: "grid frequency"
     address: 0x407
     register_type: read
     value_type: U_WORD
@@ -169,7 +169,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} output current"
+    name: "output current"
     address: 0x40A
     register_type: read
     value_type: U_WORD
@@ -182,7 +182,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} temperature"
+    name: "temperature"
     address: 0x40D
     register_type: read
     value_type: U_WORD
@@ -193,7 +193,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} inverter power"
+    name: "inverter power"
     address: 0x40e
     register_type: read
     value_type: U_WORD
@@ -205,7 +205,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: solax0
     id: solax0_power_dc1
-    name: "${name} power dc1"
+    name: "power dc1"
     address: 0x414
     register_type: read
     value_type: U_WORD
@@ -217,7 +217,7 @@ sensor:
   - platform: modbus_controller
     modbus_controller_id: solax0
     id: solax0_power_dc2
-    name: "${name} power dc2"
+    name: "power dc2"
     address: 0x415
     register_type: read
     value_type: U_WORD
@@ -231,7 +231,7 @@ sensor:
 
   - platform: template
     id: solax0_total_dc_power
-    name: "${name} total dc power"
+    name: "total dc power"
     update_interval: never
     unit_of_measurement: W
     device_class: power
@@ -242,7 +242,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} energy total"
+    name: "energy total"
     address: 0x423
     register_type: read
     value_type: U_WORD
@@ -255,7 +255,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: solax0
-    name: "${name} energy today"
+    name: "energy today"
     address: 0x425
     register_type: read
     value_type: U_WORD

--- a/modbus-examples/esp32-solax-x1-boost.yaml
+++ b/modbus-examples/esp32-solax-x1-boost.yaml
@@ -18,6 +18,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-solax-x1-mini"

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp8266-dummy-receiver.yaml
+++ b/tests/esp8266-dummy-receiver.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-query-sdm230-floats.yaml
+++ b/tests/esp8266-query-sdm230-floats.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp8266-query-sdm230.yaml
+++ b/tests/esp8266-query-sdm230.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.