### PR TITLE
Use ESP-IDF framework

### DIFF
--- a/esp32-example-advanced-multiple-uarts.yaml
+++ b/esp32-example-advanced-multiple-uarts.yaml
@@ -23,6 +23,8 @@ esphome:
 
 esp32:
   board: esp-wrover-kit
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -15,6 +15,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-meter-gateway-multiple-uarts.yaml
+++ b/esp32-meter-gateway-multiple-uarts.yaml
@@ -22,6 +22,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-meter-gateway.yaml
+++ b/esp32-meter-gateway.yaml
@@ -16,6 +16,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/modbus-examples/esp32-solax-x1-boost.yaml
+++ b/modbus-examples/esp32-solax-x1-boost.yaml
@@ -26,6 +26,8 @@ esphome:
 
 esp32:
   board: wemos_d1_mini32
+  framework:
+    type: esp-idf
 
 wifi:
   ssid: !secret wifi_ssid


### PR DESCRIPTION
## Summary
- Switch from Arduino to ESP-IDF framework per ESPHome 2026.1.0 deprecation warning