### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/solax_meter_gateway/number/solax_number.cpp
+++ b/components/solax_meter_gateway/number/solax_number.cpp
@@ -1,8 +1,7 @@
 #include "solax_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace solax_meter_gateway {
+namespace esphome::solax_meter_gateway {
 
 static const char *const TAG = "solax_meter_gateway.number";
 
@@ -32,5 +31,4 @@ void SolaxNumber::control(float value) {
 }
 void SolaxNumber::dump_config() { LOG_NUMBER("", "SolaxMeterGateway Number", this); }
 
-}  // namespace solax_meter_gateway
-}  // namespace esphome
+}  // namespace esphome::solax_meter_gateway

--- a/components/solax_meter_gateway/number/solax_number.h
+++ b/components/solax_meter_gateway/number/solax_number.h
@@ -5,8 +5,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace solax_meter_gateway {
+namespace esphome::solax_meter_gateway {
 
 class SolaxMeterGateway;
 
@@ -31,5 +30,4 @@ class SolaxNumber : public number::Number, public Component {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace solax_meter_gateway
-}  // namespace esphome
+}  // namespace esphome::solax_meter_gateway

--- a/components/solax_meter_gateway/solax_meter_gateway.cpp
+++ b/components/solax_meter_gateway/solax_meter_gateway.cpp
@@ -1,8 +1,7 @@
 #include "solax_meter_gateway.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace solax_meter_gateway {
+namespace esphome::solax_meter_gateway {
 
 static const char *const TAG = "solax_meter_gateway";
 
@@ -148,5 +147,4 @@ void SolaxMeterGateway::publish_state_(text_sensor::TextSensor *text_sensor, con
   text_sensor->publish_state(state);
 }
 
-}  // namespace solax_meter_gateway
-}  // namespace esphome
+}  // namespace esphome::solax_meter_gateway

--- a/components/solax_meter_gateway/solax_meter_gateway.h
+++ b/components/solax_meter_gateway/solax_meter_gateway.h
@@ -7,8 +7,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/solax_meter_modbus/solax_meter_modbus.h"
 
-namespace esphome {
-namespace solax_meter_gateway {
+namespace esphome::solax_meter_gateway {
 
 class SolaxMeterGateway : public PollingComponent, public solax_meter_modbus::SolaxMeterModbusDevice {
  public:
@@ -63,5 +62,4 @@ class SolaxMeterGateway : public PollingComponent, public solax_meter_modbus::So
   bool inactivity_timeout_();
 };
 
-}  // namespace solax_meter_gateway
-}  // namespace esphome
+}  // namespace esphome::solax_meter_gateway

--- a/components/solax_meter_gateway/switch/solax_switch.cpp
+++ b/components/solax_meter_gateway/switch/solax_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace solax_meter_gateway {
+namespace esphome::solax_meter_gateway {
 
 static const char *const TAG = "solax_meter_gateway.switch";
 
@@ -54,5 +53,4 @@ void SolaxSwitch::dump_config() {
 }
 void SolaxSwitch::write_state(bool state) { this->publish_state(state); }
 
-}  // namespace solax_meter_gateway
-}  // namespace esphome
+}  // namespace esphome::solax_meter_gateway

--- a/components/solax_meter_gateway/switch/solax_switch.h
+++ b/components/solax_meter_gateway/switch/solax_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace solax_meter_gateway {
+namespace esphome::solax_meter_gateway {
 
 enum SolaxSwitchRestoreMode {
   SOLAX_SWITCH_RESTORE_DEFAULT_OFF,
@@ -30,5 +29,4 @@ class SolaxSwitch : public switch_::Switch, public Component {
   SolaxSwitchRestoreMode restore_mode_{SOLAX_SWITCH_RESTORE_DEFAULT_OFF};
 };
 
-}  // namespace solax_meter_gateway
-}  // namespace esphome
+}  // namespace esphome::solax_meter_gateway

--- a/components/solax_meter_modbus/solax_meter_modbus.cpp
+++ b/components/solax_meter_modbus/solax_meter_modbus.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace solax_meter_modbus {
+namespace esphome::solax_meter_modbus {
 
 static const char *const TAG = "solax_meter_modbus";
 
@@ -181,5 +180,4 @@ void SolaxMeterModbus::send_raw(const std::vector<uint8_t> &payload) {
   ESP_LOGV(TAG, "SolaxMeterModbus write raw: %s", format_hex_pretty(payload).c_str());  // NOLINT
 }
 
-}  // namespace solax_meter_modbus
-}  // namespace esphome
+}  // namespace esphome::solax_meter_modbus

--- a/components/solax_meter_modbus/solax_meter_modbus.h
+++ b/components/solax_meter_modbus/solax_meter_modbus.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace solax_meter_modbus {
+namespace esphome::solax_meter_modbus {
 
 class SolaxMeterModbusDevice;
 
@@ -54,5 +53,4 @@ class SolaxMeterModbusDevice {
   uint8_t address_;
 };
 
-}  // namespace solax_meter_modbus
-}  // namespace esphome
+}  // namespace esphome::solax_meter_modbus

--- a/components/solax_modbus/solax_modbus.cpp
+++ b/components/solax_modbus/solax_modbus.cpp
@@ -4,8 +4,7 @@
 
 static const uint8_t BROADCAST_ADDRESS = 0xFF;
 
-namespace esphome {
-namespace solax_modbus {
+namespace esphome::solax_modbus {
 
 static const char *const TAG = "solax_modbus";
 
@@ -247,5 +246,4 @@ void SolaxModbus::send(SolaxMessageT *tx_message) {
     this->flow_control_pin_->digital_write(false);
 }
 
-}  // namespace solax_modbus
-}  // namespace esphome
+}  // namespace esphome::solax_modbus

--- a/components/solax_modbus/solax_modbus.h
+++ b/components/solax_modbus/solax_modbus.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace solax_modbus {
+namespace esphome::solax_modbus {
 
 struct SolaxMessageT {
   uint8_t Header[2];
@@ -68,5 +67,4 @@ class SolaxModbusDevice {
   uint8_t *serial_number_;
 };
 
-}  // namespace solax_modbus
-}  // namespace esphome
+}  // namespace esphome::solax_modbus

--- a/components/solax_x1_mini/solax_x1_mini.cpp
+++ b/components/solax_x1_mini/solax_x1_mini.cpp
@@ -1,8 +1,7 @@
 #include "solax_x1_mini.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace solax_x1_mini {
+namespace esphome::solax_x1_mini {
 
 static const char *const TAG = "solax_x1_mini";
 
@@ -365,5 +364,4 @@ std::string SolaxX1Mini::error_bits_to_string_(const uint32_t mask) {
   return values;
 }
 
-}  // namespace solax_x1_mini
-}  // namespace esphome
+}  // namespace esphome::solax_x1_mini

--- a/components/solax_x1_mini/solax_x1_mini.h
+++ b/components/solax_x1_mini/solax_x1_mini.h
@@ -5,8 +5,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/solax_modbus/solax_modbus.h"
 
-namespace esphome {
-namespace solax_x1_mini {
+namespace esphome::solax_x1_mini {
 
 static const uint8_t REDISCOVERY_THRESHOLD = 5;
 
@@ -90,5 +89,4 @@ class SolaxX1Mini : public PollingComponent, public solax_modbus::SolaxModbusDev
   std::string error_bits_to_string_(uint32_t bitmask);
 };
 
-}  // namespace solax_x1_mini
-}  // namespace esphome
+}  // namespace esphome::solax_x1_mini


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.