### PR TITLE
Add C++ tests for solax_meter_modbus and solax_modbus

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -567,7 +567,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py solax_x1_mini solax_meter_gateway
+          script/cpp_unit_test.py solax_x1_mini solax_meter_gateway solax_meter_modbus solax_modbus
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -567,8 +567,7 @@ jobs:
       - name: Run C++ unit tests
         run: |
           . venv/bin/activate
-          script/cpp_unit_test.py solax_x1_mini
-          script/cpp_unit_test.py solax_meter_gateway
+          script/cpp_unit_test.py solax_x1_mini solax_meter_gateway
         env:
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
           ASAN_OPTIONS: detect_leaks=0

--- a/tests/components/solax_meter_modbus/common.h
+++ b/tests/components/solax_meter_modbus/common.h
@@ -55,8 +55,11 @@ class TestableSolaxMeterModbus : public SolaxMeterModbus {
 
   bool feed(const std::vector<uint8_t> &frame) {
     bool result = false;
-    for (uint8_t byte : frame)
+    for (uint8_t byte : frame) {
       result = parse_solax_meter_modbus_byte_(byte);
+      if (!result)
+        this->rx_buffer_.clear();
+    }
     return result;
   }
 };

--- a/tests/components/solax_meter_modbus/common.h
+++ b/tests/components/solax_meter_modbus/common.h
@@ -32,8 +32,7 @@ static const std::vector<uint8_t> HANDSHAKE_FRAME = {0x01, 0x03, 0x00, 0x0B, 0x0
 static const std::vector<uint8_t> READ_POWER_FRAME = {0x01, 0x04, 0x00, 0x0C, 0x00, 0x02, 0xB1, 0xC8};
 
 // Same payload as handshake but for address=0x02
-static const std::vector<uint8_t> HANDSHAKE_FRAME_ADDR02 =
-    make_meter_frame(0x02, {0x03, 0x00, 0x0B, 0x00, 0x01});
+static const std::vector<uint8_t> HANDSHAKE_FRAME_ADDR02 = make_meter_frame(0x02, {0x03, 0x00, 0x0B, 0x00, 0x01});
 
 class MockSolaxMeterModbusDevice : public SolaxMeterModbusDevice {
  public:

--- a/tests/components/solax_meter_modbus/common.h
+++ b/tests/components/solax_meter_modbus/common.h
@@ -1,0 +1,65 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "esphome/components/solax_meter_modbus/solax_meter_modbus.h"
+
+namespace esphome::solax_meter_modbus::testing {
+
+static uint16_t crc16_modbus(const uint8_t *data, size_t len) {
+  uint16_t crc = 0xFFFF;
+  for (size_t i = 0; i < len; i++) {
+    crc ^= data[i];
+    for (int j = 0; j < 8; j++)
+      crc = (crc & 1) ? (crc >> 1) ^ 0xA001 : (crc >> 1);
+  }
+  return crc;
+}
+
+// Frame: [address, payload[5], crc_lo, crc_hi]
+static std::vector<uint8_t> make_meter_frame(uint8_t address, const std::vector<uint8_t> &payload) {
+  std::vector<uint8_t> frame = {address};
+  frame.insert(frame.end(), payload.begin(), payload.end());
+  uint16_t crc = crc16_modbus(frame.data(), frame.size());
+  frame.push_back(crc & 0xFF);
+  frame.push_back(crc >> 8);
+  return frame;
+}
+
+// Real handshake request from inverter (address=0x01): 0x01 0x03 0x00 0x0B 0x00 0x01 0xF5 0xC8
+static const std::vector<uint8_t> HANDSHAKE_FRAME = {0x01, 0x03, 0x00, 0x0B, 0x00, 0x01, 0xF5, 0xC8};
+
+// Real read-power request (address=0x01): 0x01 0x04 0x00 0x0C 0x00 0x02 0xB1 0xC8
+static const std::vector<uint8_t> READ_POWER_FRAME = {0x01, 0x04, 0x00, 0x0C, 0x00, 0x02, 0xB1, 0xC8};
+
+// Same payload as handshake but for address=0x02
+static const std::vector<uint8_t> HANDSHAKE_FRAME_ADDR02 =
+    make_meter_frame(0x02, {0x03, 0x00, 0x0B, 0x00, 0x01});
+
+class MockSolaxMeterModbusDevice : public SolaxMeterModbusDevice {
+ public:
+  std::vector<uint8_t> received_data;
+  int call_count{0};
+
+  void on_solax_meter_modbus_data(const std::vector<uint8_t> &data) override {
+    received_data = data;
+    call_count++;
+  }
+  void send(int16_t) override {}
+  void send(float) override {}
+  void send_raw(const std::vector<uint8_t> &) override {}
+};
+
+class TestableSolaxMeterModbus : public SolaxMeterModbus {
+ public:
+  void loop() override {}
+  using SolaxMeterModbus::parse_solax_meter_modbus_byte_;
+
+  bool feed(const std::vector<uint8_t> &frame) {
+    bool result = false;
+    for (uint8_t byte : frame)
+      result = parse_solax_meter_modbus_byte_(byte);
+    return result;
+  }
+};
+
+}  // namespace esphome::solax_meter_modbus::testing

--- a/tests/components/solax_meter_modbus/solax_meter_modbus_test.cpp
+++ b/tests/components/solax_meter_modbus/solax_meter_modbus_test.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+#include "common.h"
+
+namespace esphome::solax_meter_modbus::testing {
+
+TEST(SolaxMeterModbusTest, ValidFrameDispatchedToDevice) {
+  TestableSolaxMeterModbus modbus;
+  MockSolaxMeterModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  modbus.feed(HANDSHAKE_FRAME);
+
+  EXPECT_EQ(device.call_count, 1);
+}
+
+TEST(SolaxMeterModbusTest, FrameDataPassedToDevice) {
+  TestableSolaxMeterModbus modbus;
+  MockSolaxMeterModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  modbus.feed(HANDSHAKE_FRAME);
+
+  // data = raw[1..5] = [0x03, 0x00, 0x0B, 0x00, 0x01]
+  ASSERT_EQ(device.received_data.size(), 5u);
+  EXPECT_EQ(device.received_data[0], 0x03);
+  EXPECT_EQ(device.received_data[2], 0x0B);
+}
+
+TEST(SolaxMeterModbusTest, TwoFramesDispatchedTwice) {
+  TestableSolaxMeterModbus modbus;
+  MockSolaxMeterModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  modbus.feed(HANDSHAKE_FRAME);
+  modbus.feed(READ_POWER_FRAME);
+
+  EXPECT_EQ(device.call_count, 2);
+}
+
+TEST(SolaxMeterModbusTest, BadChecksumRejected) {
+  TestableSolaxMeterModbus modbus;
+  MockSolaxMeterModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  std::vector<uint8_t> bad_frame = HANDSHAKE_FRAME;
+  bad_frame.back() ^= 0xFF;  // corrupt CRC
+  modbus.feed(bad_frame);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SolaxMeterModbusTest, UnknownAddressNotDispatched) {
+  TestableSolaxMeterModbus modbus;
+  MockSolaxMeterModbusDevice device;
+  device.set_address(0x99);
+  modbus.register_device(&device);
+
+  modbus.feed(HANDSHAKE_FRAME);  // address=0x01 != 0x99
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SolaxMeterModbusTest, NoRegisteredDeviceDoesNotCrash) {
+  TestableSolaxMeterModbus modbus;
+  modbus.feed(HANDSHAKE_FRAME);
+}
+
+TEST(SolaxMeterModbusTest, PartialFrameDoesNotDispatch) {
+  TestableSolaxMeterModbus modbus;
+  MockSolaxMeterModbusDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+
+  for (size_t i = 0; i < HANDSHAKE_FRAME.size() - 2; i++)
+    modbus.parse_solax_meter_modbus_byte_(HANDSHAKE_FRAME[i]);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SolaxMeterModbusTest, AddressMatchSelectsCorrectDevice) {
+  TestableSolaxMeterModbus modbus;
+  MockSolaxMeterModbusDevice device_01, device_02;
+  device_01.set_address(0x01);
+  device_02.set_address(0x02);
+  modbus.register_device(&device_01);
+  modbus.register_device(&device_02);
+
+  modbus.feed(HANDSHAKE_FRAME_ADDR02);
+
+  EXPECT_EQ(device_01.call_count, 0);
+  EXPECT_EQ(device_02.call_count, 1);
+}
+
+}  // namespace esphome::solax_meter_modbus::testing

--- a/tests/components/solax_meter_modbus/test.host.yaml
+++ b/tests/components/solax_meter_modbus/test.host.yaml
@@ -1,0 +1,7 @@
+uart:
+  - id: uart_bus
+    baud_rate: 9600
+
+solax_meter_modbus:
+  - id: modbus_bus
+    uart_id: uart_bus

--- a/tests/components/solax_modbus/common.h
+++ b/tests/components/solax_modbus/common.h
@@ -15,9 +15,8 @@ static uint16_t solax_chksum(const uint8_t *data, uint8_t len) {
 
 // Frame: [0xAA,0x55,src0,src1(=address),dst0,dst1,cc,fc,data_len,data...,crc_hi,crc_lo]
 static std::vector<uint8_t> make_solax_frame(uint8_t address, uint8_t cc, uint8_t fc,
-                                              const std::vector<uint8_t> &data) {
-  std::vector<uint8_t> frame = {0xAA, 0x55, 0x00, address, 0x01, 0x00, cc, fc,
-                                 static_cast<uint8_t>(data.size())};
+                                             const std::vector<uint8_t> &data) {
+  std::vector<uint8_t> frame = {0xAA, 0x55, 0x00, address, 0x01, 0x00, cc, fc, static_cast<uint8_t>(data.size())};
   frame.insert(frame.end(), data.begin(), data.end());
   // chksum over frame[0..8+data_len-1]: length arg = 9 + data.size() - 1
   uint16_t crc = solax_chksum(frame.data(), static_cast<uint8_t>(9 + data.size() - 1));

--- a/tests/components/solax_modbus/common.h
+++ b/tests/components/solax_modbus/common.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include "esphome/components/solax_modbus/solax_modbus.h"
+
+namespace esphome::solax_modbus::testing {
+
+// Reimplements solax_modbus.cpp static chksum (sums bytes 0..len inclusive)
+static uint16_t solax_chksum(const uint8_t *data, uint8_t len) {
+  uint16_t s = 0;
+  for (uint8_t i = 0; i <= len; i++)
+    s += data[i];
+  return s;
+}
+
+// Frame: [0xAA,0x55,src0,src1(=address),dst0,dst1,cc,fc,data_len,data...,crc_hi,crc_lo]
+static std::vector<uint8_t> make_solax_frame(uint8_t address, uint8_t cc, uint8_t fc,
+                                              const std::vector<uint8_t> &data) {
+  std::vector<uint8_t> frame = {0xAA, 0x55, 0x00, address, 0x01, 0x00, cc, fc,
+                                 static_cast<uint8_t>(data.size())};
+  frame.insert(frame.end(), data.begin(), data.end());
+  // chksum over frame[0..8+data_len-1]: length arg = 9 + data.size() - 1
+  uint16_t crc = solax_chksum(frame.data(), static_cast<uint8_t>(9 + data.size() - 1));
+  frame.push_back(crc >> 8);
+  frame.push_back(crc & 0xFF);
+  return frame;
+}
+
+// Status response from address=0x0A, control_code=0x11, function=0x02, no data
+static const std::vector<uint8_t> STATUS_FRAME = make_solax_frame(0x0A, 0x11, 0x02, {});
+
+// Status response from address=0x01
+static const std::vector<uint8_t> STATUS_FRAME_ADDR01 = make_solax_frame(0x01, 0x11, 0x02, {});
+
+// Frame with non-dispatch control code 0x10 from address=0x0A
+static const std::vector<uint8_t> WRONG_CC_FRAME = make_solax_frame(0x0A, 0x10, 0x02, {});
+
+class MockSolaxModbusDevice : public SolaxModbusDevice {
+ public:
+  uint8_t last_function{0};
+  std::vector<uint8_t> received_data;
+  int call_count{0};
+
+  void on_solax_modbus_data(const uint8_t &function, const std::vector<uint8_t> &data) override {
+    last_function = function;
+    received_data = data;
+    call_count++;
+  }
+};
+
+class TestableSolaxModbus : public SolaxModbus {
+ public:
+  void loop() override {}
+  using SolaxModbus::parse_solax_modbus_byte_;
+
+  bool feed(const std::vector<uint8_t> &frame) {
+    bool result = false;
+    for (uint8_t byte : frame)
+      result = parse_solax_modbus_byte_(byte);
+    return result;
+  }
+};
+
+}  // namespace esphome::solax_modbus::testing

--- a/tests/components/solax_modbus/common.h
+++ b/tests/components/solax_modbus/common.h
@@ -54,8 +54,11 @@ class TestableSolaxModbus : public SolaxModbus {
 
   bool feed(const std::vector<uint8_t> &frame) {
     bool result = false;
-    for (uint8_t byte : frame)
+    for (uint8_t byte : frame) {
       result = parse_solax_modbus_byte_(byte);
+      if (!result)
+        this->rx_buffer_.clear();
+    }
     return result;
   }
 };

--- a/tests/components/solax_modbus/solax_modbus_test.cpp
+++ b/tests/components/solax_modbus/solax_modbus_test.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+#include "common.h"
+
+namespace esphome::solax_modbus::testing {
+
+TEST(SolaxModbusTest, ValidFrameDispatchedToDevice) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device;
+  device.set_address(0x0A);
+  modbus.register_device(&device);
+
+  modbus.feed(STATUS_FRAME);
+
+  EXPECT_EQ(device.call_count, 1);
+}
+
+TEST(SolaxModbusTest, FunctionCodePassedToDevice) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device;
+  device.set_address(0x0A);
+  modbus.register_device(&device);
+
+  modbus.feed(STATUS_FRAME);
+
+  EXPECT_EQ(device.last_function, 0x02);
+}
+
+TEST(SolaxModbusTest, TwoFramesDispatchedTwice) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device;
+  device.set_address(0x0A);
+  modbus.register_device(&device);
+
+  modbus.feed(STATUS_FRAME);
+  modbus.feed(STATUS_FRAME);
+
+  EXPECT_EQ(device.call_count, 2);
+}
+
+TEST(SolaxModbusTest, BadChecksumRejected) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device;
+  device.set_address(0x0A);
+  modbus.register_device(&device);
+
+  std::vector<uint8_t> bad_frame = STATUS_FRAME;
+  bad_frame.back() ^= 0xFF;  // corrupt checksum
+  modbus.feed(bad_frame);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SolaxModbusTest, UnknownAddressNotDispatched) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device;
+  device.set_address(0x99);
+  modbus.register_device(&device);
+
+  modbus.feed(STATUS_FRAME);  // address=0x0A != 0x99
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SolaxModbusTest, NoRegisteredDeviceDoesNotCrash) {
+  TestableSolaxModbus modbus;
+  modbus.feed(STATUS_FRAME);
+}
+
+TEST(SolaxModbusTest, PartialFrameDoesNotDispatch) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device;
+  device.set_address(0x0A);
+  modbus.register_device(&device);
+
+  for (size_t i = 0; i < STATUS_FRAME.size() - 2; i++)
+    modbus.parse_solax_modbus_byte_(STATUS_FRAME[i]);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SolaxModbusTest, ErrorBitInSecondByteRejected) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device;
+  device.set_address(0x0A);
+  modbus.register_device(&device);
+
+  // Feed byte 0 (valid), then byte 1 with high bit set (error indicator)
+  modbus.parse_solax_modbus_byte_(0xAA);
+  bool result = modbus.parse_solax_modbus_byte_(0x85);  // high bit set -> error
+  EXPECT_FALSE(result);
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SolaxModbusTest, NonDispatchControlCodeNoCallback) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device;
+  device.set_address(0x0A);
+  modbus.register_device(&device);
+
+  // cc=0x10 -> device is found but on_solax_modbus_data is not called
+  modbus.feed(WRONG_CC_FRAME);
+
+  EXPECT_EQ(device.call_count, 0);
+}
+
+TEST(SolaxModbusTest, AddressMatchSelectsCorrectDevice) {
+  TestableSolaxModbus modbus;
+  MockSolaxModbusDevice device_0a, device_01;
+  device_0a.set_address(0x0A);
+  device_01.set_address(0x01);
+  modbus.register_device(&device_0a);
+  modbus.register_device(&device_01);
+
+  modbus.feed(STATUS_FRAME_ADDR01);
+
+  EXPECT_EQ(device_0a.call_count, 0);
+  EXPECT_EQ(device_01.call_count, 1);
+}
+
+}  // namespace esphome::solax_modbus::testing

--- a/tests/components/solax_modbus/test.host.yaml
+++ b/tests/components/solax_modbus/test.host.yaml
@@ -1,0 +1,7 @@
+uart:
+  - id: uart_bus
+    baud_rate: 9600
+
+solax_modbus:
+  - id: modbus_bus
+    uart_id: uart_bus


### PR DESCRIPTION
## Summary

- Add `tests/components/solax_meter_modbus/` with 7 GTest-based host tests for the `SolaxMeterModbus` transport layer
- Add `tests/components/solax_modbus/` with 9 GTest-based host tests for the `SolaxModbus` transport layer
- Tests cover: frame dispatch, data/function passthrough, CRC validation, address routing, partial frames, multi-device selection, error-bit rejection, and non-dispatch control codes
- `solax_meter_modbus` uses real frames from the source code comments (handshake and read-power requests) plus a CRC-16/MODBUS helper for synthesizing frames with arbitrary addresses
- `solax_modbus` uses a reimplemented `solax_chksum` helper (mirrors the static function in the .cpp) to build valid frames for each scenario

## Test plan

- [ ] CI runs host tests via `test.host.yaml` for both components
- [ ] All 16 test cases pass