### PR TITLE
Introduce SENSOR_DEFS in solax_meter_gateway and extend schema tests

### DIFF
--- a/components/solax_meter_gateway/sensor.py
+++ b/components/solax_meter_gateway/sensor.py
@@ -26,7 +26,10 @@ SENSOR_DEFS = {
 }
 
 CONFIG_SCHEMA = CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA.extend(
-    {cv.Optional(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
+    {
+        cv.Optional(key): sensor.sensor_schema(**kwargs)
+        for key, kwargs in SENSOR_DEFS.items()
+    }
 )
 
 

--- a/components/solax_meter_gateway/sensor.py
+++ b/components/solax_meter_gateway/sensor.py
@@ -15,21 +15,24 @@ CODEOWNERS = ["@syssi"]
 
 CONF_POWER_DEMAND = "power_demand"
 
+SENSOR_DEFS = {
+    CONF_POWER_DEMAND: {
+        "unit_of_measurement": UNIT_WATT,
+        "icon": ICON_EMPTY,
+        "accuracy_decimals": 0,
+        "device_class": DEVICE_CLASS_POWER,
+        "state_class": STATE_CLASS_MEASUREMENT,
+    },
+}
+
 CONFIG_SCHEMA = CONF_SOLAX_METER_GATEWAY_COMPONENT_SCHEMA.extend(
-    {
-        cv.Optional(CONF_POWER_DEMAND): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            icon=ICON_EMPTY,
-            accuracy_decimals=0,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-    }
+    {cv.Optional(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_SOLAX_METER_GATEWAY_ID])
-    if CONF_POWER_DEMAND in config:
-        sens = await sensor.new_sensor(config[CONF_POWER_DEMAND])
-        cg.add(hub.set_power_demand_sensor(sens))
+    for key in SENSOR_DEFS:
+        if key in config:
+            sens = await sensor.new_sensor(config[key])
+            cg.add(getattr(hub, f"set_{key}_sensor")(sens))

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import components.solax_meter_gateway as hub_gateway  # noqa: E402
 from components.solax_meter_gateway import (  # noqa: E402
     number as gateway_number,
+    sensor as gateway_sensor,
     switch as gateway_switch,
     text_sensor as gateway_text_sensor,
 )
@@ -32,6 +33,15 @@ class TestSolaxX1MiniTextSensorConstants:
     def test_text_sensor_consts_defined(self):
         assert text_sensor.CONF_MODE_NAME == "mode_name"
         assert text_sensor.CONF_ERRORS == "errors"
+
+
+class TestSolaxMeterGatewaySensorDefs:
+    def test_sensor_defs_completeness(self):
+        assert gateway_sensor.CONF_POWER_DEMAND in gateway_sensor.SENSOR_DEFS
+        assert len(gateway_sensor.SENSOR_DEFS) == 1
+
+    def test_sensor_defs_keys_match_schema(self):
+        assert set(gateway_sensor.SENSOR_DEFS.keys()) == {gateway_sensor.CONF_POWER_DEMAND}
 
 
 class TestSolaxMeterGatewayTextSensorConstants:

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -8,10 +8,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import components.solax_meter_gateway as hub_gateway  # noqa: E402
 from components.solax_meter_gateway import (  # noqa: E402
     number as gateway_number,
-    sensor as gateway_sensor,
     switch as gateway_switch,
     text_sensor as gateway_text_sensor,
 )
+import components.solax_meter_gateway.sensor as gateway_sensor  # noqa: E402
 import components.solax_x1_mini as hub  # noqa: E402
 from components.solax_x1_mini import sensor, text_sensor  # noqa: E402
 
@@ -41,7 +41,9 @@ class TestSolaxMeterGatewaySensorDefs:
         assert len(gateway_sensor.SENSOR_DEFS) == 1
 
     def test_sensor_defs_keys_match_schema(self):
-        assert set(gateway_sensor.SENSOR_DEFS.keys()) == {gateway_sensor.CONF_POWER_DEMAND}
+        assert set(gateway_sensor.SENSOR_DEFS.keys()) == {
+            gateway_sensor.CONF_POWER_DEMAND
+        }
 
 
 class TestSolaxMeterGatewayTextSensorConstants:


### PR DESCRIPTION
## Summary

- Replaces the inline `sensor.sensor_schema()` call in `solax_meter_gateway/sensor.py` with a `SENSOR_DEFS` dict
- Since both schema registration and code generation iterate over the same dict, it is structurally impossible to declare a sensor without registering it
- Adds `TestSolaxMeterGatewaySensorDefs` to `tests/test_component_schemas.py` covering the previously untested gateway sensor module

## Test plan

- [ ] `pytest tests/test_component_schemas.py` passes
- [ ] `solax_meter_gateway` sensor schema unchanged from user perspective (`power_demand` still optional)