### PR TITLE
Use ESPHome devices concept in multi-device examples

### DIFF
--- a/esp32-example-advanced-multiple-uarts.yaml
+++ b/esp32-example-advanced-multiple-uarts.yaml
@@ -91,207 +91,207 @@ text_sensor:
   - platform: solax_x1_mini
     solax_x1_mini_id: solax0
     mode_name:
-      name: "${device0} mode name"
+      name: "mode name"
       device_id: device0
     errors:
-      name: "${device0} errors"
+      name: "errors"
       device_id: device0
 
   - platform: solax_x1_mini
     solax_x1_mini_id: solax1
     mode_name:
-      name: "${device1} mode name"
+      name: "mode name"
       device_id: device1
     errors:
-      name: "${device1} errors"
+      name: "errors"
       device_id: device1
 
   - platform: solax_x1_mini
     solax_x1_mini_id: solax2
     mode_name:
-      name: "${device2} mode name"
+      name: "mode name"
       device_id: device2
     errors:
-      name: "${device2} errors"
+      name: "errors"
       device_id: device2
 
 sensor:
   - platform: solax_x1_mini
     solax_x1_mini_id: solax0
     ac_power:
-      name: "${device0} ac power"
+      name: "ac power"
       device_id: device0
     energy_today:
-      name: "${device0} energy today"
+      name: "energy today"
       device_id: device0
     energy_total:
-      name: "${device0} energy total"
+      name: "energy total"
       device_id: device0
     dc1_voltage:
-      name: "${device0} dc1 voltage"
+      name: "dc1 voltage"
       device_id: device0
     dc1_current:
-      name: "${device0} dc1 current"
+      name: "dc1 current"
       device_id: device0
     ac_current:
-      name: "${device0} ac current"
+      name: "ac current"
       device_id: device0
     ac_voltage:
-      name: "${device0} ac voltage"
+      name: "ac voltage"
       device_id: device0
     ac_frequency:
-      name: "${device0} ac frequency"
+      name: "ac frequency"
       device_id: device0
     temperature:
-      name: "${device0} temperature"
+      name: "temperature"
       device_id: device0
     runtime_total:
-      name: "${device0} runtime total"
+      name: "runtime total"
       device_id: device0
     mode:
-      name: "${device0} mode"
+      name: "mode"
       device_id: device0
     error_bits:
-      name: "${device0} error bits"
+      name: "error bits"
       device_id: device0
     grid_voltage_fault:
-      name: "${device0} grid voltage fault"
+      name: "grid voltage fault"
       device_id: device0
     grid_frequency_fault:
-      name: "${device0} grid frequency fault"
+      name: "grid frequency fault"
       device_id: device0
     dc_injection_fault:
-      name: "${device0} dc injection fault"
+      name: "dc injection fault"
       device_id: device0
     temperature_fault:
-      name: "${device0} temperature fault"
+      name: "temperature fault"
       device_id: device0
     pv1_voltage_fault:
-      name: "${device0} pv1 voltage fault"
+      name: "pv1 voltage fault"
       device_id: device0
     pv2_voltage_fault:
-      name: "${device0} pv2 voltage fault"
+      name: "pv2 voltage fault"
       device_id: device0
     gfc_fault:
-      name: "${device0} gfc fault"
+      name: "gfc fault"
       device_id: device0
 
   - platform: solax_x1_mini
     solax_x1_mini_id: solax1
     ac_power:
-      name: "${device1} ac power"
+      name: "ac power"
       device_id: device1
     energy_today:
-      name: "${device1} energy today"
+      name: "energy today"
       device_id: device1
     energy_total:
-      name: "${device1} energy total"
+      name: "energy total"
       device_id: device1
     dc1_voltage:
-      name: "${device1} dc1 voltage"
+      name: "dc1 voltage"
       device_id: device1
     dc1_current:
-      name: "${device1} dc1 current"
+      name: "dc1 current"
       device_id: device1
     ac_current:
-      name: "${device1} ac current"
+      name: "ac current"
       device_id: device1
     ac_voltage:
-      name: "${device1} ac voltage"
+      name: "ac voltage"
       device_id: device1
     ac_frequency:
-      name: "${device1} ac frequency"
+      name: "ac frequency"
       device_id: device1
     temperature:
-      name: "${device1} temperature"
+      name: "temperature"
       device_id: device1
     runtime_total:
-      name: "${device1} runtime total"
+      name: "runtime total"
       device_id: device1
     mode:
-      name: "${device1} mode"
+      name: "mode"
       device_id: device1
     error_bits:
-      name: "${device1} error bits"
+      name: "error bits"
       device_id: device1
     grid_voltage_fault:
-      name: "${device1} grid voltage fault"
+      name: "grid voltage fault"
       device_id: device1
     grid_frequency_fault:
-      name: "${device1} grid frequency fault"
+      name: "grid frequency fault"
       device_id: device1
     dc_injection_fault:
-      name: "${device1} dc injection fault"
+      name: "dc injection fault"
       device_id: device1
     temperature_fault:
-      name: "${device1} temperature fault"
+      name: "temperature fault"
       device_id: device1
     pv1_voltage_fault:
-      name: "${device1} pv1 voltage fault"
+      name: "pv1 voltage fault"
       device_id: device1
     pv2_voltage_fault:
-      name: "${device1} pv2 voltage fault"
+      name: "pv2 voltage fault"
       device_id: device1
     gfc_fault:
-      name: "${device1} gfc fault"
+      name: "gfc fault"
       device_id: device1
 
   - platform: solax_x1_mini
     solax_x1_mini_id: solax2
     ac_power:
-      name: "${device2} ac power"
+      name: "ac power"
       device_id: device2
     energy_today:
-      name: "${device2} energy today"
+      name: "energy today"
       device_id: device2
     energy_total:
-      name: "${device2} energy total"
+      name: "energy total"
       device_id: device2
     dc1_voltage:
-      name: "${device2} dc1 voltage"
+      name: "dc1 voltage"
       device_id: device2
     dc1_current:
-      name: "${device2} dc1 current"
+      name: "dc1 current"
       device_id: device2
     ac_current:
-      name: "${device2} ac current"
+      name: "ac current"
       device_id: device2
     ac_voltage:
-      name: "${device2} ac voltage"
+      name: "ac voltage"
       device_id: device2
     ac_frequency:
-      name: "${device2} ac frequency"
+      name: "ac frequency"
       device_id: device2
     temperature:
-      name: "${device2} temperature"
+      name: "temperature"
       device_id: device2
     runtime_total:
-      name: "${device2} runtime total"
+      name: "runtime total"
       device_id: device2
     mode:
-      name: "${device2} mode"
+      name: "mode"
       device_id: device2
     error_bits:
-      name: "${device2} error bits"
+      name: "error bits"
       device_id: device2
     grid_voltage_fault:
-      name: "${device2} grid voltage fault"
+      name: "grid voltage fault"
       device_id: device2
     grid_frequency_fault:
-      name: "${device2} grid frequency fault"
+      name: "grid frequency fault"
       device_id: device2
     dc_injection_fault:
-      name: "${device2} dc injection fault"
+      name: "dc injection fault"
       device_id: device2
     temperature_fault:
-      name: "${device2} temperature fault"
+      name: "temperature fault"
       device_id: device2
     pv1_voltage_fault:
-      name: "${device2} pv1 voltage fault"
+      name: "pv1 voltage fault"
       device_id: device2
     pv2_voltage_fault:
-      name: "${device2} pv2 voltage fault"
+      name: "pv2 voltage fault"
       device_id: device2
     gfc_fault:
-      name: "${device2} gfc fault"
+      name: "gfc fault"
       device_id: device2

--- a/esp32-meter-gateway-multiple-uarts.yaml
+++ b/esp32-meter-gateway-multiple-uarts.yaml
@@ -106,39 +106,39 @@ sensor:
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway0
     power_demand:
-      name: "${device0} power demand"
+      name: "power demand"
       device_id: device0
 
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway1
     power_demand:
-      name: "${device1} power demand"
+      name: "power demand"
       device_id: device1
 
 text_sensor:
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway0
     operation_mode:
-      name: "${device0} operation mode"
+      name: "operation mode"
       device_id: device0
 
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway1
     operation_mode:
-      name: "${device1} operation mode"
+      name: "operation mode"
       device_id: device1
 
 switch:
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway0
     emergency_power_off:
-      name: "${device0} emergency power off"
+      name: "emergency power off"
       device_id: device0
       restore_mode: RESTORE_DEFAULT_OFF
 
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway1
     emergency_power_off:
-      name: "${device1} emergency power off"
+      name: "emergency power off"
       device_id: device1
       restore_mode: RESTORE_DEFAULT_OFF

--- a/esp8266-meter-gateway-multiple-uarts.yaml
+++ b/esp8266-meter-gateway-multiple-uarts.yaml
@@ -104,39 +104,39 @@ sensor:
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway0
     power_demand:
-      name: "${device0} power demand"
+      name: "power demand"
       device_id: device0
 
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway1
     power_demand:
-      name: "${device1} power demand"
+      name: "power demand"
       device_id: device1
 
 text_sensor:
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway0
     operation_mode:
-      name: "${device0} operation mode"
+      name: "operation mode"
       device_id: device0
 
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway1
     operation_mode:
-      name: "${device1} operation mode"
+      name: "operation mode"
       device_id: device1
 
 switch:
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway0
     emergency_power_off:
-      name: "${device0} emergency power off"
+      name: "emergency power off"
       device_id: device0
       restore_mode: RESTORE_DEFAULT_OFF
 
   - platform: solax_meter_gateway
     solax_meter_gateway_id: solax_meter_gateway1
     emergency_power_off:
-      name: "${device1} emergency power off"
+      name: "emergency power off"
       device_id: device1
       restore_mode: RESTORE_DEFAULT_OFF


### PR DESCRIPTION
Remove `${deviceN}` name prefixes from entity names in all multi-device example configs. The `devices` block was already present; this removes the now-redundant prefix so that entity names are clean and grouping is done exclusively via `device_id`.

Affected files:
- `esp32-example-advanced-multiple-uarts.yaml`
- `esp32-meter-gateway-multiple-uarts.yaml`
- `esp8266-meter-gateway-multiple-uarts.yaml`