### PR TITLE
Replace locally defined unit constant with esphome.const import

### DIFF
--- a/components/solax_x1_mini/sensor.py
+++ b/components/solax_x1_mini/sensor.py
@@ -20,6 +20,7 @@ from esphome.const import (
     UNIT_CELSIUS,
     UNIT_EMPTY,
     UNIT_HERTZ,
+    UNIT_HOUR,
     UNIT_KILOWATT_HOURS,
     UNIT_VOLT,
     UNIT_WATT,
@@ -49,8 +50,6 @@ CONF_TEMPERATURE_FAULT = "temperature_fault"
 CONF_PV1_VOLTAGE_FAULT = "pv1_voltage_fault"
 CONF_PV2_VOLTAGE_FAULT = "pv2_voltage_fault"
 CONF_GFC_FAULT = "gfc_fault"
-
-UNIT_HOURS = "h"
 
 ICON_MODE = "mdi:heart-pulse"
 ICON_ERROR_BITS = "mdi:alert-circle-outline"
@@ -120,7 +119,7 @@ SENSOR_DEFS = {
         "state_class": STATE_CLASS_MEASUREMENT,
     },
     CONF_RUNTIME_TOTAL: {
-        "unit_of_measurement": UNIT_HOURS,
+        "unit_of_measurement": UNIT_HOUR,
         "icon": ICON_TIMER,
         "accuracy_decimals": 0,
         "device_class": DEVICE_CLASS_EMPTY,


### PR DESCRIPTION
## Summary

The `solax_x1_mini` sensor platform defined a local `UNIT_HOURS = "h"` constant. The canonical `UNIT_HOUR` is already available in `esphome.const`, so this imports it and removes the duplicate.

| Local definition | Replaced by |
|---|---|
| `UNIT_HOURS = "h"` | `UNIT_HOUR` |

**Affected files:** `solax_x1_mini/sensor`

No functional change — the string value is identical.