### PR TITLE
Add configurable meter_type parameter for X3 G2/MIC support

### DIFF
--- a/components/solax_meter_gateway/__init__.py
+++ b/components/solax_meter_gateway/__init__.py
@@ -13,6 +13,7 @@ CONF_SOLAX_METER_GATEWAY_ID = "solax_meter_gateway_id"
 CONF_POWER_ID = "power_id"
 CONF_POWER_SENSOR_INACTIVITY_TIMEOUT = "power_sensor_inactivity_timeout"
 CONF_OPERATION_MODE_ID = "operation_mode_id"
+CONF_METER_TYPE = "meter_type"
 
 DEFAULT_MIN_POWER_DEMAND = 0
 DEFAULT_MAX_POWER_DEMAND = 600
@@ -38,6 +39,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_POWER_SENSOR_INACTIVITY_TIMEOUT, default="5s"
             ): cv.positive_time_period_seconds,
+            cv.Optional(CONF_METER_TYPE, default=0x0000): cv.int_range(
+                min=0, max=0xFFFF
+            ),
         }
     )
     .extend(solax_meter_modbus.solax_meter_modbus_device_schema(0x01))
@@ -58,3 +62,4 @@ async def to_code(config):
             config[CONF_POWER_SENSOR_INACTIVITY_TIMEOUT]
         )
     )
+    cg.add(var.set_meter_type(config[CONF_METER_TYPE]))

--- a/components/solax_meter_gateway/solax_meter_gateway.cpp
+++ b/components/solax_meter_gateway/solax_meter_gateway.cpp
@@ -50,8 +50,9 @@ void SolaxMeterGateway::on_solax_meter_modbus_data(const std::vector<uint8_t> &d
       // Request: 0x01 0x03 0x00 0x0B 0x00 0x01 0xF5 0xC8
       //          addr func      reg       bytes*2
       if (++this->consecutive_handshake_count_ % 5 == 0) {
-        ESP_LOGE(TAG, "Meter type 0x%04X not accepted after %u handshakes. "
-                      "Configure a different meter_type (e.g. 0x0000, 0x00A6, 0x00A8).",
+        ESP_LOGE(TAG,
+                 "Meter type 0x%04X not accepted after %u handshakes. "
+                 "Configure a different meter_type (e.g. 0x0000, 0x00A6, 0x00A8).",
                  this->meter_type_, this->consecutive_handshake_count_);
       }
       this->send_raw({0x01, 0x03, 0x02, uint8_t(this->meter_type_ >> 8), uint8_t(this->meter_type_ & 0xFF)});

--- a/components/solax_meter_gateway/solax_meter_gateway.cpp
+++ b/components/solax_meter_gateway/solax_meter_gateway.cpp
@@ -41,11 +41,12 @@ void SolaxMeterGateway::on_solax_meter_modbus_data(const std::vector<uint8_t> &d
   }
 
   uint8_t register_address = data[2];
+
   switch (register_address) {
     case REGISTER_HANDSHAKE:
       // Request: 0x01 0x03 0x00 0x0B 0x00 0x01 0xF5 0xC8
       //          addr func      reg       bytes*2
-      this->send_raw({0x01, 0x03, 0x02, 0x00, 0x00});
+      this->send_raw({0x01, 0x03, 0x02, uint8_t(this->meter_type_ >> 8), uint8_t(this->meter_type_ & 0xFF)});
       break;
 
     case REGISTER_READ_POWER_32BIT_FLOAT:
@@ -109,6 +110,7 @@ void SolaxMeterGateway::setup() {
 void SolaxMeterGateway::dump_config() {
   ESP_LOGCONFIG(TAG, "SolaxMeterGateway:");
   ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "  Meter type: 0x%04X", this->meter_type_);
   LOG_SENSOR("  ", "Power Demand", this->power_demand_sensor_);
   LOG_TEXT_SENSOR("  ", "Operation name", this->operation_mode_text_sensor_);
 }

--- a/components/solax_meter_gateway/solax_meter_gateway.cpp
+++ b/components/solax_meter_gateway/solax_meter_gateway.cpp
@@ -42,10 +42,18 @@ void SolaxMeterGateway::on_solax_meter_modbus_data(const std::vector<uint8_t> &d
 
   uint8_t register_address = data[2];
 
+  if (register_address != REGISTER_HANDSHAKE)
+    this->consecutive_handshake_count_ = 0;
+
   switch (register_address) {
     case REGISTER_HANDSHAKE:
       // Request: 0x01 0x03 0x00 0x0B 0x00 0x01 0xF5 0xC8
       //          addr func      reg       bytes*2
+      if (++this->consecutive_handshake_count_ % 5 == 0) {
+        ESP_LOGE(TAG, "Meter type 0x%04X not accepted after %u handshakes. "
+                      "Configure a different meter_type (e.g. 0x0000, 0x00A6, 0x00A8).",
+                 this->meter_type_, this->consecutive_handshake_count_);
+      }
       this->send_raw({0x01, 0x03, 0x02, uint8_t(this->meter_type_ >> 8), uint8_t(this->meter_type_ & 0xFF)});
       break;
 

--- a/components/solax_meter_gateway/solax_meter_gateway.cpp
+++ b/components/solax_meter_gateway/solax_meter_gateway.cpp
@@ -11,6 +11,7 @@ static const uint8_t REGISTER_READ_POWER_32BIT_FLOAT = 0x0C;
 static const uint8_t REGISTER_READ_TOTAL_ENERGY = 0x08;
 static const uint8_t REGISTER_READ_TOTAL_ENERGY_IMPORT_32BIT_FLOAT = 0x48;
 static const uint8_t REGISTER_READ_TOTAL_ENERGY_EXPORT_32BIT_FLOAT = 0x4A;
+static const uint8_t HANDSHAKE_ERROR_THRESHOLD = 6;
 
 void SolaxMeterGateway::on_solax_meter_modbus_data(const std::vector<uint8_t> &data) {
   this->last_solax_request_received_ = millis();
@@ -49,7 +50,7 @@ void SolaxMeterGateway::on_solax_meter_modbus_data(const std::vector<uint8_t> &d
     case REGISTER_HANDSHAKE:
       // Request: 0x01 0x03 0x00 0x0B 0x00 0x01 0xF5 0xC8
       //          addr func      reg       bytes*2
-      if (++this->consecutive_handshake_count_ % 5 == 0) {
+      if (++this->consecutive_handshake_count_ % HANDSHAKE_ERROR_THRESHOLD == 0) {
         ESP_LOGE(TAG,
                  "Meter type 0x%04X not accepted after %u handshakes. "
                  "Configure a different meter_type (e.g. 0x0000, 0x00A6, 0x00A8).",

--- a/components/solax_meter_gateway/solax_meter_gateway.h
+++ b/components/solax_meter_gateway/solax_meter_gateway.h
@@ -59,6 +59,7 @@ class SolaxMeterGateway : public PollingComponent, public solax_meter_modbus::So
   uint16_t solax_request_inactivity_timeout_s_{10};
   uint32_t last_power_demand_received_{0};
   uint32_t last_solax_request_received_{0};
+  uint8_t consecutive_handshake_count_{0};
 
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);

--- a/components/solax_meter_gateway/solax_meter_gateway.h
+++ b/components/solax_meter_gateway/solax_meter_gateway.h
@@ -30,6 +30,8 @@ class SolaxMeterGateway : public PollingComponent, public solax_meter_modbus::So
     operation_mode_text_sensor_ = operation_mode_text_sensor;
   }
 
+  void set_meter_type(uint16_t meter_type) { meter_type_ = meter_type; }
+
   void setup() override;
 
   void on_solax_meter_modbus_data(const std::vector<uint8_t> &data) override;
@@ -52,6 +54,7 @@ class SolaxMeterGateway : public PollingComponent, public solax_meter_modbus::So
   text_sensor::TextSensor *operation_mode_text_sensor_{nullptr};
 
   float power_demand_;
+  uint16_t meter_type_{0x0000};
   uint16_t power_sensor_inactivity_timeout_s_{0};
   uint16_t solax_request_inactivity_timeout_s_{10};
   uint32_t last_power_demand_received_{0};

--- a/esp32-meter-gateway-multiple-uarts.yaml
+++ b/esp32-meter-gateway-multiple-uarts.yaml
@@ -78,7 +78,7 @@ solax_meter_gateway:
     # Meter type returned during the RS485 handshake (register 0x0B).
     # Some inverters validate this value and keep repeating the handshake until
     # the smart meter responds with a supported type. Progress past the handshake
-    # is impossible with a wrong value. After every 5 consecutive unaccepted
+    # is impossible with a wrong value. After every 6 consecutive unaccepted
     # handshakes an error is logged suggesting to try a different value.
     # Known working values:
     #   0x0000 - Solax X1 mini
@@ -98,7 +98,7 @@ solax_meter_gateway:
     # Meter type returned during the RS485 handshake (register 0x0B).
     # Some inverters validate this value and keep repeating the handshake until
     # the smart meter responds with a supported type. Progress past the handshake
-    # is impossible with a wrong value. After every 5 consecutive unaccepted
+    # is impossible with a wrong value. After every 6 consecutive unaccepted
     # handshakes an error is logged suggesting to try a different value.
     # Known working values:
     #   0x0000 - Solax X1 mini

--- a/esp32-meter-gateway-multiple-uarts.yaml
+++ b/esp32-meter-gateway-multiple-uarts.yaml
@@ -75,8 +75,11 @@ solax_meter_gateway:
     power_sensor_inactivity_timeout: 5s
     update_interval: 5s
 
-    # Meter type reported during the handshake (register 0x0B). Must match what
-    # the inverter expects or it will ignore all subsequent power demand reads.
+    # Meter type returned during the RS485 handshake (register 0x0B).
+    # Some inverters validate this value and keep repeating the handshake until
+    # the smart meter responds with a supported type. Progress past the handshake
+    # is impossible with a wrong value. After every 5 consecutive unaccepted
+    # handshakes an error is logged suggesting to try a different value.
     # Known working values:
     #   0x0000 - Solax X1 mini
     #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)
@@ -92,8 +95,11 @@ solax_meter_gateway:
     power_sensor_inactivity_timeout: 5s
     update_interval: 5s
 
-    # Meter type reported during the handshake (register 0x0B). Must match what
-    # the inverter expects or it will ignore all subsequent power demand reads.
+    # Meter type returned during the RS485 handshake (register 0x0B).
+    # Some inverters validate this value and keep repeating the handshake until
+    # the smart meter responds with a supported type. Progress past the handshake
+    # is impossible with a wrong value. After every 5 consecutive unaccepted
+    # handshakes an error is logged suggesting to try a different value.
     # Known working values:
     #   0x0000 - Solax X1 mini
     #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)

--- a/esp32-meter-gateway-multiple-uarts.yaml
+++ b/esp32-meter-gateway-multiple-uarts.yaml
@@ -75,6 +75,14 @@ solax_meter_gateway:
     power_sensor_inactivity_timeout: 5s
     update_interval: 5s
 
+    # Meter type reported during the handshake (register 0x0B). Must match what
+    # the inverter expects or it will ignore all subsequent power demand reads.
+    # Known working values:
+    #   0x0000 - Solax X1 mini
+    #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)
+    #   0x00A8 - Solax X3 MIC Gen1, X3 G2/MIC (SDM230 meter identity)
+    meter_type: 0x0000
+
   - id: solax_meter_gateway1
     solax_meter_modbus_id: modbus1
     address: 0x01
@@ -83,6 +91,14 @@ solax_meter_gateway:
     power_id: powermeter1
     power_sensor_inactivity_timeout: 5s
     update_interval: 5s
+
+    # Meter type reported during the handshake (register 0x0B). Must match what
+    # the inverter expects or it will ignore all subsequent power demand reads.
+    # Known working values:
+    #   0x0000 - Solax X1 mini
+    #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)
+    #   0x00A8 - Solax X3 MIC Gen1, X3 G2/MIC (SDM230 meter identity)
+    meter_type: 0x0000
 
 sensor:
   - id: powermeter0

--- a/esp32-meter-gateway.yaml
+++ b/esp32-meter-gateway.yaml
@@ -65,8 +65,11 @@ solax_meter_gateway:
   power_sensor_inactivity_timeout: 5s
   update_interval: 5s
 
-  # Meter type reported during the handshake (register 0x0B). Must match what
-  # the inverter expects or it will ignore all subsequent power demand reads.
+  # Meter type returned during the RS485 handshake (register 0x0B).
+  # Some inverters validate this value and keep repeating the handshake until
+  # the smart meter responds with a supported type. Progress past the handshake
+  # is impossible with a wrong value. After every 5 consecutive unaccepted
+  # handshakes an error is logged suggesting to try a different value.
   # Known working values:
   #   0x0000 - Solax X1 mini
   #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)

--- a/esp32-meter-gateway.yaml
+++ b/esp32-meter-gateway.yaml
@@ -68,7 +68,7 @@ solax_meter_gateway:
   # Meter type returned during the RS485 handshake (register 0x0B).
   # Some inverters validate this value and keep repeating the handshake until
   # the smart meter responds with a supported type. Progress past the handshake
-  # is impossible with a wrong value. After every 5 consecutive unaccepted
+  # is impossible with a wrong value. After every 6 consecutive unaccepted
   # handshakes an error is logged suggesting to try a different value.
   # Known working values:
   #   0x0000 - Solax X1 mini

--- a/esp32-meter-gateway.yaml
+++ b/esp32-meter-gateway.yaml
@@ -65,6 +65,14 @@ solax_meter_gateway:
   power_sensor_inactivity_timeout: 5s
   update_interval: 5s
 
+  # Meter type reported during the handshake (register 0x0B). Must match what
+  # the inverter expects or it will ignore all subsequent power demand reads.
+  # Known working values:
+  #   0x0000 - Solax X1 mini
+  #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)
+  #   0x00A8 - Solax X3 MIC Gen1, X3 G2/MIC (SDM230 meter identity)
+  meter_type: 0x0000
+
 sensor:
   - id: powermeter0
     internal: true

--- a/esp8266-meter-gateway-multiple-uarts.yaml
+++ b/esp8266-meter-gateway-multiple-uarts.yaml
@@ -76,7 +76,7 @@ solax_meter_gateway:
     # Meter type returned during the RS485 handshake (register 0x0B).
     # Some inverters validate this value and keep repeating the handshake until
     # the smart meter responds with a supported type. Progress past the handshake
-    # is impossible with a wrong value. After every 5 consecutive unaccepted
+    # is impossible with a wrong value. After every 6 consecutive unaccepted
     # handshakes an error is logged suggesting to try a different value.
     # Known working values:
     #   0x0000 - Solax X1 mini
@@ -96,7 +96,7 @@ solax_meter_gateway:
     # Meter type returned during the RS485 handshake (register 0x0B).
     # Some inverters validate this value and keep repeating the handshake until
     # the smart meter responds with a supported type. Progress past the handshake
-    # is impossible with a wrong value. After every 5 consecutive unaccepted
+    # is impossible with a wrong value. After every 6 consecutive unaccepted
     # handshakes an error is logged suggesting to try a different value.
     # Known working values:
     #   0x0000 - Solax X1 mini

--- a/esp8266-meter-gateway-multiple-uarts.yaml
+++ b/esp8266-meter-gateway-multiple-uarts.yaml
@@ -73,6 +73,14 @@ solax_meter_gateway:
     power_sensor_inactivity_timeout: 5s
     update_interval: 5s
 
+    # Meter type reported during the handshake (register 0x0B). Must match what
+    # the inverter expects or it will ignore all subsequent power demand reads.
+    # Known working values:
+    #   0x0000 - Solax X1 mini
+    #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)
+    #   0x00A8 - Solax X3 MIC Gen1, X3 G2/MIC (SDM230 meter identity)
+    meter_type: 0x0000
+
   - id: solax_meter_gateway1
     solax_meter_modbus_id: modbus1
     address: 0x01
@@ -81,6 +89,14 @@ solax_meter_gateway:
     power_id: powermeter1
     power_sensor_inactivity_timeout: 5s
     update_interval: 5s
+
+    # Meter type reported during the handshake (register 0x0B). Must match what
+    # the inverter expects or it will ignore all subsequent power demand reads.
+    # Known working values:
+    #   0x0000 - Solax X1 mini
+    #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)
+    #   0x00A8 - Solax X3 MIC Gen1, X3 G2/MIC (SDM230 meter identity)
+    meter_type: 0x0000
 
 sensor:
   - id: powermeter0

--- a/esp8266-meter-gateway-multiple-uarts.yaml
+++ b/esp8266-meter-gateway-multiple-uarts.yaml
@@ -73,8 +73,11 @@ solax_meter_gateway:
     power_sensor_inactivity_timeout: 5s
     update_interval: 5s
 
-    # Meter type reported during the handshake (register 0x0B). Must match what
-    # the inverter expects or it will ignore all subsequent power demand reads.
+    # Meter type returned during the RS485 handshake (register 0x0B).
+    # Some inverters validate this value and keep repeating the handshake until
+    # the smart meter responds with a supported type. Progress past the handshake
+    # is impossible with a wrong value. After every 5 consecutive unaccepted
+    # handshakes an error is logged suggesting to try a different value.
     # Known working values:
     #   0x0000 - Solax X1 mini
     #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)
@@ -90,8 +93,11 @@ solax_meter_gateway:
     power_sensor_inactivity_timeout: 5s
     update_interval: 5s
 
-    # Meter type reported during the handshake (register 0x0B). Must match what
-    # the inverter expects or it will ignore all subsequent power demand reads.
+    # Meter type returned during the RS485 handshake (register 0x0B).
+    # Some inverters validate this value and keep repeating the handshake until
+    # the smart meter responds with a supported type. Progress past the handshake
+    # is impossible with a wrong value. After every 5 consecutive unaccepted
+    # handshakes an error is logged suggesting to try a different value.
     # Known working values:
     #   0x0000 - Solax X1 mini
     #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)

--- a/esp8266-meter-gateway.yaml
+++ b/esp8266-meter-gateway.yaml
@@ -63,6 +63,14 @@ solax_meter_gateway:
   power_sensor_inactivity_timeout: 5s
   update_interval: 5s
 
+  # Meter type reported during the handshake (register 0x0B). Must match what
+  # the inverter expects or it will ignore all subsequent power demand reads.
+  # Known working values:
+  #   0x0000 - Solax X1 mini
+  #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)
+  #   0x00A8 - Solax X3 MIC Gen1, X3 G2/MIC (SDM230 meter identity)
+  meter_type: 0x0000
+
 sensor:
   - id: powermeter0
     internal: true

--- a/esp8266-meter-gateway.yaml
+++ b/esp8266-meter-gateway.yaml
@@ -66,7 +66,7 @@ solax_meter_gateway:
   # Meter type returned during the RS485 handshake (register 0x0B).
   # Some inverters validate this value and keep repeating the handshake until
   # the smart meter responds with a supported type. Progress past the handshake
-  # is impossible with a wrong value. After every 5 consecutive unaccepted
+  # is impossible with a wrong value. After every 6 consecutive unaccepted
   # handshakes an error is logged suggesting to try a different value.
   # Known working values:
   #   0x0000 - Solax X1 mini

--- a/esp8266-meter-gateway.yaml
+++ b/esp8266-meter-gateway.yaml
@@ -63,8 +63,11 @@ solax_meter_gateway:
   power_sensor_inactivity_timeout: 5s
   update_interval: 5s
 
-  # Meter type reported during the handshake (register 0x0B). Must match what
-  # the inverter expects or it will ignore all subsequent power demand reads.
+  # Meter type returned during the RS485 handshake (register 0x0B).
+  # Some inverters validate this value and keep repeating the handshake until
+  # the smart meter responds with a supported type. Progress past the handshake
+  # is impossible with a wrong value. After every 5 consecutive unaccepted
+  # handshakes an error is logged suggesting to try a different value.
   # Known working values:
   #   0x0000 - Solax X1 mini
   #   0x00A6 - Solax X1 Hybrid Gen2+, SK-SU3700E (DDSU666 meter identity)

--- a/tests/components/solax_meter_gateway/common.h
+++ b/tests/components/solax_meter_gateway/common.h
@@ -21,6 +21,7 @@ class TestableSolaxMeterGateway : public SolaxMeterGateway {
 
   uint32_t get_last_solax_request_received() const { return this->last_solax_request_received_; }
   uint32_t get_last_power_demand_received() const { return this->last_power_demand_received_; }
+  uint8_t get_consecutive_handshake_count() const { return this->consecutive_handshake_count_; }
 
   void call_update() { SolaxMeterGateway::update(); }
 };

--- a/tests/components/solax_meter_gateway/common.h
+++ b/tests/components/solax_meter_gateway/common.h
@@ -14,7 +14,7 @@ class TestableSolaxMeterGateway : public SolaxMeterGateway {
   void update() override {}
   void send(int16_t power) override {}
   void send(float power) override {}
-  void send_raw(const std::vector<uint8_t> &payload) override {}
+  void send_raw(const std::vector<uint8_t> &payload) override { last_raw_payload_ = payload; }
 
   void set_power_demand(float value) { this->power_demand_ = value; }
   void set_last_power_demand_received(uint32_t ts) { this->last_power_demand_received_ = ts; }
@@ -22,8 +22,12 @@ class TestableSolaxMeterGateway : public SolaxMeterGateway {
   uint32_t get_last_solax_request_received() const { return this->last_solax_request_received_; }
   uint32_t get_last_power_demand_received() const { return this->last_power_demand_received_; }
   uint8_t get_consecutive_handshake_count() const { return this->consecutive_handshake_count_; }
+  const std::vector<uint8_t> &get_last_raw_payload() const { return last_raw_payload_; }
 
   void call_update() { SolaxMeterGateway::update(); }
+
+ private:
+  std::vector<uint8_t> last_raw_payload_;
 };
 
 }  // namespace esphome::solax_meter_gateway::testing

--- a/tests/components/solax_meter_gateway/solax_meter_gateway_test.cpp
+++ b/tests/components/solax_meter_gateway/solax_meter_gateway_test.cpp
@@ -165,6 +165,34 @@ TEST(SolaxMeterGatewayInactivityTest, NoMeterFaultWhenPowerSensorRecent) {
 // At every multiple of HANDSHAKE_ERROR_THRESHOLD (6) an error is logged;
 // we verify the counter value at that point rather than the log output.
 
+// ── Handshake response contains configured meter type ─────────────────────────
+//
+// Response format: {0x01, 0x03, 0x02, hi, lo}
+// Meter type bytes are at index 3 (high) and 4 (low).
+
+TEST(SolaxMeterGatewayHandshakeTest, DefaultMeterTypeInResponse) {
+  TestableSolaxMeterGateway gw;  // default meter_type_ = 0x0000
+
+  gw.on_solax_meter_modbus_data(HANDSHAKE_REQUEST);
+
+  const auto &payload = gw.get_last_raw_payload();
+  ASSERT_EQ(payload.size(), 5u);
+  EXPECT_EQ(payload[3], 0x00u);
+  EXPECT_EQ(payload[4], 0x00u);
+}
+
+TEST(SolaxMeterGatewayHandshakeTest, ConfiguredMeterTypeInResponse) {
+  TestableSolaxMeterGateway gw;
+  gw.set_meter_type(0x00A8);
+
+  gw.on_solax_meter_modbus_data(HANDSHAKE_REQUEST);
+
+  const auto &payload = gw.get_last_raw_payload();
+  ASSERT_EQ(payload.size(), 5u);
+  EXPECT_EQ(payload[3], 0x00u);
+  EXPECT_EQ(payload[4], 0xA8u);
+}
+
 TEST(SolaxMeterGatewayHandshakeTest, CounterIncrementsOnEachHandshake) {
   TestableSolaxMeterGateway gw;
 

--- a/tests/components/solax_meter_gateway/solax_meter_gateway_test.cpp
+++ b/tests/components/solax_meter_gateway/solax_meter_gateway_test.cpp
@@ -158,6 +158,41 @@ TEST(SolaxMeterGatewayInactivityTest, NoMeterFaultWhenPowerSensorRecent) {
   EXPECT_NE(op_mode.state, "Meter fault");
 }
 
+// ── Handshake counter ─────────────────────────────────────────────────────────
+//
+// The counter increments on every REGISTER_HANDSHAKE request and resets to 0
+// as soon as any other register is received (handshake accepted).
+// At every multiple of HANDSHAKE_ERROR_THRESHOLD (6) an error is logged;
+// we verify the counter value at that point rather than the log output.
+
+TEST(SolaxMeterGatewayHandshakeTest, CounterIncrementsOnEachHandshake) {
+  TestableSolaxMeterGateway gw;
+
+  for (uint8_t i = 1; i <= 3; i++) {
+    gw.on_solax_meter_modbus_data(HANDSHAKE_REQUEST);
+    EXPECT_EQ(gw.get_consecutive_handshake_count(), i);
+  }
+}
+
+TEST(SolaxMeterGatewayHandshakeTest, CounterResetsOnNonHandshakeRegister) {
+  TestableSolaxMeterGateway gw;
+
+  gw.on_solax_meter_modbus_data(HANDSHAKE_REQUEST);
+  gw.on_solax_meter_modbus_data(HANDSHAKE_REQUEST);
+  gw.on_solax_meter_modbus_data(READ_POWER_32BIT_FLOAT_REQUEST);
+
+  EXPECT_EQ(gw.get_consecutive_handshake_count(), 0u);
+}
+
+TEST(SolaxMeterGatewayHandshakeTest, CounterAtErrorThreshold) {
+  TestableSolaxMeterGateway gw;
+
+  for (int i = 0; i < 6; i++)  // HANDSHAKE_ERROR_THRESHOLD = 6
+    gw.on_solax_meter_modbus_data(HANDSHAKE_REQUEST);
+
+  EXPECT_EQ(gw.get_consecutive_handshake_count(), 6u);
+}
+
 // ── Null sensors do not crash ─────────────────────────────────────────────────
 
 TEST(SolaxMeterGatewaySafetyTest, NullSensorsDoNotCrash) {


### PR DESCRIPTION
## Summary

Replaces three incremental attempts (hardcoded 0x00A8, hardcoded 0x00A6, auto-discover 0x00–0xFF) with an explicit `meter_type` YAML parameter.

### Background

The inverter identifies the connected smart meter via handshake register `0x0B`. Single-phase X1 inverters accept any value (including `0x0000`). Three-phase X3 G2/MIC inverters require a specific model identifier and ignore power demand reads if the wrong value is sent.

The auto-discovery approach (probing `0x00`–`0xFF` incrementally) produced false positives: the inverter appeared to accept a value but never transitioned to reading actual power demand. See #122.

### Changes

**New optional YAML parameter** (default `0x0000`, backwards-compatible):
```yaml
solax_meter_gateway:
  meter_type: 0x00A8  # Solax X3 G2/MIC
```

Known working values, documented as comments in all example configurations:

| Value | Meter identity | Inverter |
|---|---|---|
| `0x0000` | (generic) | Solax X1 mini |
| `0x00A6` | DDSU666 | Solax X1 Hybrid Gen2+, SK-SU3700E |
| `0x00A8` | SDM230 | Solax X3 MIC Gen1, X3 G2/MIC |

Closes #122