### PR TITLE
Fix inactivity tracking: update correct timestamp in on_solax_meter_modbus_data

### DIFF
--- a/components/solax_meter_gateway/solax_meter_gateway.cpp
+++ b/components/solax_meter_gateway/solax_meter_gateway.cpp
@@ -13,7 +13,7 @@ static const uint8_t REGISTER_READ_TOTAL_ENERGY_IMPORT_32BIT_FLOAT = 0x48;
 static const uint8_t REGISTER_READ_TOTAL_ENERGY_EXPORT_32BIT_FLOAT = 0x4A;
 
 void SolaxMeterGateway::on_solax_meter_modbus_data(const std::vector<uint8_t> &data) {
-  this->last_power_demand_received_ = millis();
+  this->last_solax_request_received_ = millis();
 
   if (this->inactivity_timeout_()) {
     this->publish_state_(this->operation_mode_text_sensor_, "Meter fault");

--- a/tests/components/solax_meter_gateway/common.h
+++ b/tests/components/solax_meter_gateway/common.h
@@ -17,6 +17,12 @@ class TestableSolaxMeterGateway : public SolaxMeterGateway {
   void send_raw(const std::vector<uint8_t> &payload) override {}
 
   void set_power_demand(float value) { this->power_demand_ = value; }
+  void set_last_power_demand_received(uint32_t ts) { this->last_power_demand_received_ = ts; }
+
+  uint32_t get_last_solax_request_received() const { return this->last_solax_request_received_; }
+  uint32_t get_last_power_demand_received() const { return this->last_power_demand_received_; }
+
+  void call_update() { SolaxMeterGateway::update(); }
 };
 
 }  // namespace esphome::solax_meter_gateway::testing

--- a/tests/components/solax_meter_gateway/solax_meter_gateway_test.cpp
+++ b/tests/components/solax_meter_gateway/solax_meter_gateway_test.cpp
@@ -1,8 +1,10 @@
 #include "esphome/components/solax_meter_gateway/solax_meter_gateway.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/core/hal.h"
 #include "common.h"
 #include "frames.h"
+#include <cmath>
 #include <gtest/gtest.h>
 
 namespace esphome::solax_meter_gateway::testing {
@@ -75,6 +77,85 @@ TEST(SolaxMeterGatewayTest, ManualModeNoNumber) {
 
   EXPECT_EQ(op_mode.state, "Manual");
   EXPECT_FLOAT_EQ(power_demand.state, 0.0f);
+}
+
+// ── Inactivity tracking: inverter-side ───────────────────────────────────────
+//
+// last_solax_request_received_ starts at 0; millis() on the host is always
+// far above any inactivity threshold, so update() fires "Standby" immediately
+// when the timestamp has never been updated.  After on_solax_meter_modbus_data()
+// the timestamp is current, so a back-to-back update() must stay silent.
+
+TEST(SolaxMeterGatewayInactivityTest, UpdatePublishesStandbyWhenInverterNeverPolled) {
+  TestableSolaxMeterGateway gw;
+  text_sensor::TextSensor op_mode;
+  gw.set_operation_mode_text_sensor(&op_mode);
+
+  gw.call_update();
+
+  EXPECT_EQ(op_mode.state, "Standby");
+}
+
+TEST(SolaxMeterGatewayInactivityTest, UpdateSilentImmediatelyAfterInverterPoll) {
+  TestableSolaxMeterGateway gw;
+  text_sensor::TextSensor op_mode;
+  gw.set_operation_mode_text_sensor(&op_mode);
+
+  gw.on_solax_meter_modbus_data(READ_POWER_32BIT_FLOAT_REQUEST);
+  gw.call_update();
+
+  EXPECT_NE(op_mode.state, "Standby");
+}
+
+TEST(SolaxMeterGatewayInactivityTest, InverterPollSetsRequestTimestamp) {
+  TestableSolaxMeterGateway gw;
+
+  EXPECT_EQ(gw.get_last_solax_request_received(), 0u);
+  gw.on_solax_meter_modbus_data(READ_POWER_32BIT_FLOAT_REQUEST);
+  EXPECT_GT(gw.get_last_solax_request_received(), 0u);
+}
+
+// ── Inactivity tracking: power-sensor-side ────────────────────────────────────
+//
+// last_power_demand_received_ must NOT be touched by on_solax_meter_modbus_data().
+// When it stays at 0 and a non-zero timeout is configured, the first inverter
+// poll must trigger "Meter fault".  After the power sensor timestamp is current
+// the safety path must not fire.
+
+TEST(SolaxMeterGatewayInactivityTest, InverterPollDoesNotSetPowerSensorTimestamp) {
+  TestableSolaxMeterGateway gw;
+
+  gw.on_solax_meter_modbus_data(READ_POWER_32BIT_FLOAT_REQUEST);
+
+  EXPECT_EQ(gw.get_last_power_demand_received(), 0u);
+}
+
+TEST(SolaxMeterGatewayInactivityTest, MeterFaultWhenPowerSensorSilent) {
+  TestableSolaxMeterGateway gw;
+  sensor::Sensor power_demand;
+  text_sensor::TextSensor op_mode;
+  gw.set_power_demand_sensor(&power_demand);
+  gw.set_operation_mode_text_sensor(&op_mode);
+  gw.set_power_sensor_inactivity_timeout(5);
+
+  gw.on_solax_meter_modbus_data(READ_POWER_32BIT_FLOAT_REQUEST);
+
+  EXPECT_EQ(op_mode.state, "Meter fault");
+  EXPECT_TRUE(std::isnan(power_demand.state));
+}
+
+TEST(SolaxMeterGatewayInactivityTest, NoMeterFaultWhenPowerSensorRecent) {
+  TestableSolaxMeterGateway gw;
+  sensor::Sensor power_demand;
+  text_sensor::TextSensor op_mode;
+  gw.set_power_demand_sensor(&power_demand);
+  gw.set_operation_mode_text_sensor(&op_mode);
+  gw.set_power_sensor_inactivity_timeout(5);
+  gw.set_last_power_demand_received(millis());
+
+  gw.on_solax_meter_modbus_data(READ_POWER_32BIT_FLOAT_REQUEST);
+
+  EXPECT_NE(op_mode.state, "Meter fault");
 }
 
 // ── Null sensors do not crash ─────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Two bugs in `on_solax_meter_modbus_data()`:

1. **`last_solax_request_received_` was never set.** It is initialized to `0` and only ever read in `update()`. After device uptime exceeded `solax_request_inactivity_timeout_s_` (default 10 s), the *"No solax request received"* warning fired on every `update_interval` tick — even with the inverter actively polling every 250 ms. Reported in #122.

2. **`last_power_demand_received_` was reset on every inverter poll.** This silently disabled the power-sensor inactivity safety timeout (`inactivity_timeout_()` → "Meter fault") as long as the inverter kept querying — even when the MQTT smart-meter feed had gone completely silent. In that scenario the gateway would keep forwarding a stale, potentially large power demand to the inverter indefinitely.

## Fix

Replace the wrong reset with the correct one (one line change):

```cpp
- this->last_power_demand_received_ = millis();
+ this->last_solax_request_received_ = millis();
```

Both safety paths now work independently:

| Condition | Variable tracked | Action |
|---|---|---|
| Inverter stops polling | `last_solax_request_received_` | `update()` → "Standby" + log |
| Smart-meter feed goes silent | `last_power_demand_received_` | `inactivity_timeout_()` → "Meter fault" + NAN |

## Tests

Six new `SolaxMeterGatewayInactivityTest` cases covering both paths without sleep or clock injection (host `millis()` always exceeds any threshold when a timestamp stays at `0`):

- `UpdatePublishesStandbyWhenInverterNeverPolled`
- `UpdateSilentImmediatelyAfterInverterPoll`
- `InverterPollSetsRequestTimestamp`
- `InverterPollDoesNotSetPowerSensorTimestamp`
- `MeterFaultWhenPowerSensorSilent`
- `NoMeterFaultWhenPowerSensorRecent`